### PR TITLE
Switch from GAPI to gtoken + Bug Fix

### DIFF
--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -18,12 +18,12 @@
 
 var Auth2Client = require('./oauth2client.js');
 var util = require('util');
-var GAPI = require('gapitoken');
+var gToken = require('gtoken');
 
 /**
  * JWT service account credentials.
  *
- * Retrieve access token using gapitoken.
+ * Retrieve access token using gtoken.
  *
  * @param {string=} email service account email address.
  * @param {string=} keyFile path to private key file.
@@ -39,7 +39,7 @@ function JWT(email, keyFile, key, scopes, subject) {
   this.key = key;
   this.scopes = scopes;
   this.subject = subject;
-  this.GAPI = GAPI;
+  this.gToken = gToken;
 
   this.credentials = {
     refresh_token: 'jwt-placeholder',
@@ -91,7 +91,7 @@ JWT.prototype.createScopedRequired = function() {
 };
 
 /**
- * Get the initial access token using gapitoken.
+ * Get the initial access token using gToken.
  * @param {function=} opt_callback Optional callback.
  */
 JWT.prototype.authorize = function(opt_callback) {
@@ -113,17 +113,15 @@ JWT.prototype.authorize = function(opt_callback) {
  * @private
  */
 JWT.prototype.refreshToken_ = function(ignored_, opt_callback) {
-  var that = this;
-
-  this._createGAPI(function(err, gapi) {
+  this._createGToken(function(err, gToken) {
     if (err) {
       callback(opt_callback, err);
     } else {
-      gapi.getToken(function (err, token) {
+      gToken.getToken(function (err, token) {
         callback(opt_callback, err, {
           access_token: token,
           token_type: 'Bearer',
-          expiry_date: that.gapi.token_expires * 1000
+          expiry_date: gToken.token_expires * 1000
         });
       });
     }
@@ -189,28 +187,22 @@ JWT.prototype.fromStream = function(stream, opt_callback) {
 };
 
 /**
- * Creates the GAPI instance if it has not been created already.
+ * Creates the gToken instance if it has not been created already.
  * @param {function=} callback Callback.
  * @private
  */
-JWT.prototype._createGAPI = function(callback) {
-  var that = this;
-
-  if (that.gapi) {
-    callback(null, that.gapi);
+JWT.prototype._createGToken = function(callback) {
+  if (this.gtoken) {
+    callback(null, this.gtoken);
   } else {
-    that.gapi = new that.GAPI({
-      iss: that.email,
-      sub: that.subject,
-      scope: that.scopes instanceof Array ? that.scopes.join(' ') : that.scopes,
-      keyFile: that.keyFile,
-      key: that.key
-    }, function (err) {
-      if (err) {
-        that.gapi = null;
-      }
-      callback(err, that.gapi);
+    this.gtoken = this.gToken({
+      iss: this.email,
+      sub: this.subject,
+      scope: this.scopes instanceof Array ? this.scopes.join(' ') : this.scopes,
+      keyFile: this.keyFile,
+      key: this.key
     });
+    callback(null, this.gtoken);
   }
 };
 

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -198,7 +198,7 @@ JWT.prototype._createGToken = function(callback) {
     this.gtoken = this.gToken({
       iss: this.email,
       sub: this.subject,
-      scope: this.scopes instanceof Array ? this.scopes.join(' ') : this.scopes,
+      scope: this.scopes,
       keyFile: this.keyFile,
       key: this.key
     });

--- a/lib/auth/refreshclient.js
+++ b/lib/auth/refreshclient.js
@@ -49,8 +49,8 @@ function callback(c, err, res) {
  * @private
  */
 UserRefreshClient.prototype.refreshToken_ = function(ignored_, opt_callback) {
-  UserRefreshClient.super_.prototype.refereshToken_.call(this._refreshToken,
-                                                     opt_callback);
+  UserRefreshClient.super_.prototype.refreshToken_.call(
+      this, this._refreshToken, opt_callback);
 };
 
 /**
@@ -88,6 +88,7 @@ UserRefreshClient.prototype.fromJSON = function(json, opt_callback) {
   that.clientId_ = json.client_id;
   that.clientSecret_ = json.client_secret;
   that._refreshToken = json.refresh_token;
+  that.credentials.refresh_token = json.refresh_token;
   callback(opt_callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "async": "~0.9.0",
-    "gapitoken": "~0.1.2",
+    "gtoken": "^1.1.0",
     "request": "~2.51.0",
     "string-template": "~0.2.0"
   },

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -77,7 +77,7 @@ describe('JWT auth client', function() {
     jwt.gToken = function(opts) {
       assert.equal('foo@serviceaccount.com', opts.iss);
       assert.equal('/path/to/key.pem', opts.keyFile);
-      assert.equal('http://bar http://foo', opts.scope);
+      assert.deepEqual(['http://bar', 'http://foo'], opts.scope);
       assert.equal('bar@subjectaccount.com', opts.sub);
       return {
         getToken: function(opt_callback) {

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -106,7 +106,7 @@ describe('JWT auth client', function() {
       done();
       return {
         getToken: function() {}
-      }
+      };
     };
 
     jwt.authorize();

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -74,14 +74,11 @@ describe('JWT auth client', function() {
         null,
         ['http://bar', 'http://foo'],
         'bar@subjectaccount.com');
-    jwt.GAPI = function(opts, callback) {
+    jwt.gToken = function(opts) {
       assert.equal('foo@serviceaccount.com', opts.iss);
       assert.equal('/path/to/key.pem', opts.keyFile);
       assert.equal('http://bar http://foo', opts.scope);
       assert.equal('bar@subjectaccount.com', opts.sub);
-      setTimeout(function() {
-        callback(null);
-      }, 0);
       return {
         getToken: function(opt_callback) {
           opt_callback(null, 'initial-access-token');
@@ -104,9 +101,12 @@ describe('JWT auth client', function() {
         'http://foo',
         'bar@subjectaccount.com');
 
-    jwt.GAPI = function(opts) {
+    jwt.gToken = function(opts) {
       assert.equal('http://foo', opts.scope);
       done();
+      return {
+        getToken: function() {}
+      }
     };
 
     jwt.authorize();
@@ -125,7 +125,7 @@ describe('JWT auth client', function() {
       refresh_token: 'jwt-placeholder'
     };
 
-    jwt.gapi = {
+    jwt.gtoken = {
       getToken: function(callback) {
         callback(null, 'abc123');
       }
@@ -152,7 +152,7 @@ describe('JWT auth client', function() {
       expiry_date: (new Date()).getTime() - 1000
     };
 
-    jwt.gapi = {
+    jwt.gtoken = {
       getToken: function(callback) {
         callback(null, 'abc123');
       }
@@ -234,7 +234,7 @@ describe('JWT auth client', function() {
 
     var dateInSeconds = (new Date()).getTime() / 1000;
 
-    jwt.gapi = {
+    jwt.gtoken = {
       getToken: function(callback) {
         callback(null, 'token');
       },


### PR DESCRIPTION
I switched the library to use [gtoken](https://github.com/ryanseys/node-gtoken) to add support for a path to a p12 keyfile. It's also a more well maintained and documented codebase (and made by the one and only @ryanseys).

I also caught a couple of bugs, which I will point out with comments.

(RE: https://github.com/GoogleCloudPlatform/gcloud-node/pull/458)