### PR TITLE
Do not set type on error object

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -75,10 +75,8 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
 
     if (body && body.error) {
       if (typeof body.error === 'string') {
-        err = new Error(body.error_description);
+        err = new Error(body.error);
         err.code = res.statusCode;
-        err.type = body.error;
-
       } else {
         err = new Error(body.error.message);
         err.code = body.error.code || res.statusCode;


### PR DESCRIPTION
So this PR comes with a bit of confusion behind the responsibilities of the libraries in play. There's an issue [here](https://github.com/google/google-api-nodejs-client/issues/382) which I'm trying to address with this PR. However [google-api-nodejs-client](https://github.com/google/google-api-nodejs-client) where this code originated (which I maintain), still holds the tests that are associated with these line changes [here](https://github.com/google/google-api-nodejs-client/blob/master/test/test.transporters.js#L85). 

That is, I have to send a PR here, and update the tests on the other project. That's terrible, and not the way things should work. This is because the transporter for google-api-nodejs-client now just borrows this library's transporter [as seen here](https://github.com/google/google-api-nodejs-client/blob/master/lib/transporters.js).

What should I do? Clearly this is not a maintainable as it stands. I believe those tests should be migrated from google-api-nodejs-client.