### PR TITLE
update instance email & key properties from gToken

### DIFF
--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -101,6 +101,8 @@ JWT.prototype.authorize = function(opt_callback) {
     if (!err) {
       that.credentials = result;
       that.credentials.refresh_token = 'jwt-placeholder';
+      that.key = that.gtoken.key;
+      that.email = that.gtoken.iss;
     }
     callback(opt_callback, err, result);
   });

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -80,6 +80,8 @@ describe('JWT auth client', function() {
       assert.deepEqual(['http://bar', 'http://foo'], opts.scope);
       assert.equal('bar@subjectaccount.com', opts.sub);
       return {
+        key: 'private-key-data',
+        iss: 'foo@subjectaccount.com',
         getToken: function(opt_callback) {
           opt_callback(null, 'initial-access-token');
         }
@@ -88,6 +90,8 @@ describe('JWT auth client', function() {
     jwt.authorize(function() {
       assert.equal('initial-access-token', jwt.credentials.access_token);
       assert.equal('jwt-placeholder', jwt.credentials.refresh_token);
+      assert.equal('private-key-data', jwt.key);
+      assert.equal('foo@subjectaccount.com', jwt.email);
       done();
     });
   });


### PR DESCRIPTION
When given a path to a keyfile, gtoken will update its own instance with the extracted email & key data after parsing it from the file. These values are useful to expose to users, as an example, for when [trying to create a signed URL for Storage access](https://github.com/stephenplusplus/gcloud-node/blob/spp--auth/lib/storage/file.js#L774-789).

Ping @ryanseys to see if this is a reliable way to get these values.