### PR TITLE
Create a meaningful error from response.error.errors array

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -77,6 +77,14 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
       if (typeof body.error === 'string') {
         err = new Error(body.error);
         err.code = res.statusCode;
+
+      } else if (Array.isArray(body.error.errors)) {
+        err = new Error(body.error.errors.map(
+                         function(err) { return err.message; }
+                       ).join('\n'));
+        err.code = body.error.errors[0].code;
+        err.errors = body.error.errors;
+
       } else {
         err = new Error(body.error.message);
         err.code = body.error.code || res.statusCode;

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -41,4 +41,32 @@ describe('Transporters', function() {
     var re = new RegExp(applicationName + ' ' + defaultUserAgentRE);
     assert(re.test(opts.headers['User-Agent']));
   });
+
+  it('should create a single error from multiple response errors', function(done) {
+    var firstError = {
+      message: 'Error 1',
+      code: 'ERR1',
+    };
+    var secondError = {
+      message: 'Error 2',
+      code: 'ERR2',
+    };
+    nock('http://example.com')
+      .get('/api')
+      .reply(200, {
+        error: {
+          errors: [ firstError, secondError ]
+        }
+      });
+
+    transporter.request({
+      uri: 'http://example.com/api',
+    }, function(error) {
+      assert(error.message === 'Error 1\nError 2');
+      assert(error.code, 'ERR1');
+      assert(error.errors.length, 2);
+      assert(error.errors[1].code, 'ERR2');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Certain API responses include an array of errors, rather than just one - e.g. https://cloud.google.com/compute/docs/reference/latest/regionOperations . Currently this throws a fairly useless error with an `undefined` message and an error code of `200`.

When `error.errors` is an array, this patch includes an error text with newline-joined messages from each individual error, the `code` from the first error, and an `errors` field with the underlying array of error objects.