### PR TITLE
Prevent status 200 responses from being reported as errors.

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -73,7 +73,7 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
       body = JSON.parse(body);
     } catch (err) { /* no op */ }
 
-    if (body && body.error) {
+    if (body && body.error && res.statusCode != 200) {
       if (typeof body.error === 'string') {
         err = new Error(body.error);
         err.code = res.statusCode;

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -51,7 +51,7 @@ describe('Transporters', function() {
     };
     nock('http://example.com')
       .get('/api')
-      .reply(200, {
+      .reply(400, {
         error: {
           code: 500,
           errors: [ firstError, secondError ]


### PR DESCRIPTION
The current set up will report a response as an error if the response contains an 'error' field, even if the status code is 200.  When it does this, any other information in the response gets discarded.

This change will prevent status code 200 responses from being interpreted as Errors.