### PR TITLE
Use metadata.google.internal

### DIFF
--- a/lib/auth/computeclient.js
+++ b/lib/auth/computeclient.js
@@ -24,7 +24,7 @@ var util = require('util');
  * @private
  */
 Compute.GOOGLE_OAUTH2_TOKEN_URL_ =
-  'http://metadata/computeMetadata/v1beta1/instance/service-accounts/default/token';
+  'http://metadata.google.internal/computeMetadata/v1beta1/instance/service-accounts/default/token';
 
 /**
  * Google Compute Engine service account credentials.


### PR DESCRIPTION
Using the full hostname rather than requiring the resolv.conf domain configuration is required for our setup.