### PR TITLE
Accept the new issuer value for Google ID tokens.

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -97,11 +97,11 @@ OAuth2Client.CLOCK_SKEW_SECS_ = 300;
 OAuth2Client.MAX_TOKEN_LIFETIME_SECS_ = 86400;
 
 /**
- * The oauth token issuer.
+ * The allowed oauth token issuers.
  * @const
  * @private
  */
-OAuth2Client.ISSUER_ = 'accounts.google.com';
+OAuth2Client.ISSUERS_ = ['accounts.google.com', 'https://accounts.google.com'];
 
 /**
  * Generates URL for consent page landing.
@@ -400,7 +400,7 @@ OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
     var login;
     try {
       login = this.verifySignedJwtWithCerts(idToken, certs, audience,
-        OAuth2Client.ISSUER_);
+        OAuth2Client.ISSUERS_);
     } catch (err) {
       callback(err);
       return;
@@ -457,12 +457,12 @@ OAuth2Client.prototype.getFederatedSignonCerts = function(callback) {
  * @param {string} jwt The jwt to verify (The ID Token in this case).
  * @param {array} certs The array of certs to test the jwt against.
  * @param {string} requiredAudience The audience to test the jwt against.
- * @param {string} issuer The issuer of the jwt (Optional).
+ * @param {array} issuers The allowed issuers of the jwt (Optional).
  * @param {string} maxExpiry The max expiry the certificate can be (Optional).
  * @return {LoginTicket} Returns a LoginTicket on verification.
  */
 OAuth2Client.prototype.verifySignedJwtWithCerts =
-  function(jwt, certs, requiredAudience, issuer, maxExpiry) {
+  function(jwt, certs, requiredAudience, issuers, maxExpiry) {
 
     if (!maxExpiry) {
       maxExpiry = OAuth2Client.MAX_TOKEN_LIFETIME_SECS_;
@@ -530,8 +530,9 @@ OAuth2Client.prototype.verifySignedJwtWithCerts =
         JSON.stringify(payload));
     }
 
-    if (issuer && issuer !== payload.iss) {
-      throw new Error('Invalid issuer, ' + issuer + ' != ' + payload.iss);
+    if (issuers && issuers.indexOf(payload.iss) < 0) {
+      throw new Error('Invalid issuer, expected one of [' + issuers +
+          '], but got ' + payload.iss);
     }
 
     // Check the audience matches if we have one

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -609,7 +609,7 @@ describe('OAuth2 client', function() {
       data,
       {keyid: publicKey},
       'testaudience',
-      'testissuer',
+      ['testissuer'],
       maxExpiry
     );
 
@@ -762,7 +762,7 @@ describe('OAuth2 client', function() {
           data,
           {keyid: publicKey},
           'testaudience',
-          'testissuer'
+          ['testissuer']
         );
       },
       /Invalid issuer/
@@ -811,7 +811,7 @@ describe('OAuth2 client', function() {
       data,
       {keyid: publicKey},
       'testaudience',
-      'testissuer'
+      ['testissuer']
     );
 
     done();


### PR DESCRIPTION
Google used to use "accounts.google.com" as the ID token issuer and now is using "https://accounts.google.com" in its OpenId Connect spec compliant endpoints. Per https://developers.google.com/identity/protocols/OpenIDConnect?hl=en#sendauthrequest, both "accounts.google.com" and "https://accounts.google.com" should be accepted.