### PR TITLE
Added support for array of valid audiences

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -384,7 +384,7 @@ OAuth2Client.prototype._postRequest = function(err, result, response, callback) 
 /**
  * Verify id token is token by checking the certs and audience
  * @param {string} idToken ID Token.
- * @param {string} audience The audience to verify against the ID Token
+ * @param {(string|Array.<string>)} audience The audience to verify against the ID Token
  * @param {function=} callback Callback supplying GoogleLogin if successful
  */
 OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
@@ -456,7 +456,7 @@ OAuth2Client.prototype.getFederatedSignonCerts = function(callback) {
  * and is from the correct audience.
  * @param {string} jwt The jwt to verify (The ID Token in this case).
  * @param {array} certs The array of certs to test the jwt against.
- * @param {string} requiredAudience The audience to test the jwt against.
+ * @param {(string|Array.<string>)} requiredAudience The audience to test the jwt against.
  * @param {array} issuers The allowed issuers of the jwt (Optional).
  * @param {string} maxExpiry The max expiry the certificate can be (Optional).
  * @return {LoginTicket} Returns a LoginTicket on verification.
@@ -538,8 +538,17 @@ OAuth2Client.prototype.verifySignedJwtWithCerts =
     // Check the audience matches if we have one
     if (typeof requiredAudience !== 'undefined' && requiredAudience !== null) {
       var aud = payload.aud;
-      if (aud !== requiredAudience) {
-        throw new Error('Wrong recipient, payload audience != requiredAudience');
+      var audVerified = false;
+      //If the requiredAudience is an array, check if it contains token audience
+      if(requiredAudience.constructor === Array)
+      {
+          audVerified = (requiredAudience.indexOf(aud) > -1);
+      }
+      else{
+          audVerified = (aud === requiredAudience);
+      }
+      if (!audVerified) {
+         throw new Error('Wrong recipient, payload audience != requiredAudience');
       }
     }
 

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -222,6 +222,16 @@ describe('OAuth2 client', function() {
       },
       /Wrong recipient/
     );
+    assert.throws(
+      function() {
+        oauth2client.verifySignedJwtWithCerts(
+          data,
+          {keyid: publicKey},
+          ['testaudience','extra-audience']
+        );
+      },
+      /No valid recipients in array/
+    );
 
     done();
   });


### PR DESCRIPTION
Added support for array of multiple valid audiences to verify a Google
ID token.

Based on the support for similar functionality in the [Java library](https://developers.google.com/api-client-library/java/google-api-java-client/reference/1.20.0/com/google/api/client/googleapis/auth/oauth2/GoogleIdTokenVerifier.Builder#setAudience%28java.util.Collection%29)