### PR TITLE
Don't depend on a library to get the noop function

### DIFF
--- a/lib/auth/jwtaccess.js
+++ b/lib/auth/jwtaccess.js
@@ -17,7 +17,9 @@
 'use strict';
 
 var jws = require('jws');
-var noop = require('lodash.noop');
+
+function noop() {
+}
 
 /**
  * JWTAccess service account credentials.

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -19,9 +19,10 @@
 var Auth2Client = require('./oauth2client.js');
 var gToken = require('gtoken');
 var JWTAccess = require('./jwtaccess.js');
-var noop = require('lodash.noop');
 var util = require('util');
 
+function noop() {
+}
 
 /**
  * JWT service account credentials.

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -18,10 +18,12 @@
 
 var AuthClient = require('./authclient.js');
 var LoginTicket = require('./loginticket.js');
-var noop = require('lodash.noop');
 var PemVerifier = require('./../pemverifier.js');
 var querystring = require('querystring');
 var util = require('util');
+
+function noop() {
+}
 
 var certificateCache = null;
 var certificateExpiry = null;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "async": "~1.4.2",
     "gtoken": "^1.1.0",
-    "lodash.noop": "~3.0.0",
     "jws": "~3.0.0",
     "request": "~2.60.0",
     "string-template": "~0.2.0"


### PR DESCRIPTION
We don't need to depend on a library just to get `function() {}`.