### PR TITLE
Capitalize constructor names everywhere to satisfy linter

### DIFF
--- a/lib/auth/googleauth.js
+++ b/lib/auth/googleauth.js
@@ -22,7 +22,7 @@ var fs = require('fs');
 var os = require('os');
 var path = require('path');
 var util = require('util');
-var defaultTransporter = require('../transporters.js');
+var DefaultTransporter = require('../transporters.js');
 
 /**
  * GoogleAuth account manager.
@@ -161,7 +161,7 @@ GoogleAuth.prototype._checkIsGCE = function(callback) {
     callback(that._isGCE);
   } else {
     if (!that.transporter) {
-      that.transporter = new defaultTransporter();
+      that.transporter = new DefaultTransporter();
     }
     that.transporter.request({
       method: 'GET',

--- a/test/test.compute.js
+++ b/test/test.compute.js
@@ -17,7 +17,7 @@
 'use strict';
 
 var assert = require('assert');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var nock = require('nock');
 
 nock.disableNetConnect();
@@ -27,7 +27,7 @@ describe('Initial credentials', function() {
   it('should create a dummy refresh token string', function () {
     // It is important that the compute client is created with a refresh token value filled
     // in, or else the rest of the logic will not work.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var compute = new auth.Compute();
     assert.equal('compute-placeholder', compute.credentials.refresh_token);
   });
@@ -37,7 +37,7 @@ describe('Compute auth client', function() {
   // set up compute client.
   var compute;
   beforeEach(function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     compute = new auth.Compute();
   });
 
@@ -81,7 +81,7 @@ describe('Compute auth client', function() {
 
   describe('.createScopedRequired', function () {
     it('should return false', function () {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var compute = new auth.Compute();
       assert.equal(false, compute.createScopedRequired());
     });

--- a/test/test.googleauth.js
+++ b/test/test.googleauth.js
@@ -17,7 +17,7 @@
 'use strict';
 
 var assert = require('assert');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var nock = require('nock');
 var fs = require('fs');
 
@@ -117,11 +117,11 @@ function doneWhen(doneCallback, count) {
   };
 }
 
-describe('googleAuth', function() {
+describe('GoogleAuth', function() {
   describe('.fromJson', function () {
 
     it('should error on null json', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromJSON(null, function (err) {
         assert.equal(true, err instanceof Error);
         done();
@@ -131,7 +131,7 @@ describe('googleAuth', function() {
     describe('JWT token', function() {
 
       it('should error on empty json', function (done) {
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON({}, function (err) {
           assert.equal(true, err instanceof Error);
           done();
@@ -142,7 +142,7 @@ describe('googleAuth', function() {
         var json = createJwtJSON();
         delete json.client_email;
 
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err) {
           assert.equal(true, err instanceof Error);
           done();
@@ -153,7 +153,7 @@ describe('googleAuth', function() {
         var json = createJwtJSON();
         delete json.private_key;
 
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err) {
           assert.equal(true, err instanceof Error);
           done();
@@ -162,7 +162,7 @@ describe('googleAuth', function() {
 
       it('should create JWT with client_email', function (done) {
         var json = createJwtJSON();
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err, result) {
           assert.equal(null, err);
           assert.equal(json.client_email, result.email);
@@ -172,7 +172,7 @@ describe('googleAuth', function() {
 
       it('should create JWT with private_key', function (done) {
         var json = createJwtJSON();
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err, result) {
           assert.equal(null, err);
           assert.equal(json.private_key, result.key);
@@ -182,7 +182,7 @@ describe('googleAuth', function() {
 
       it('should create JWT with null scopes', function (done) {
         var json = createJwtJSON();
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err, result) {
           assert.equal(null, err);
           assert.equal(null, result.scopes);
@@ -192,7 +192,7 @@ describe('googleAuth', function() {
 
       it('should create JWT with null subject', function (done) {
         var json = createJwtJSON();
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err, result) {
           assert.equal(null, err);
           assert.equal(null, result.subject);
@@ -202,7 +202,7 @@ describe('googleAuth', function() {
 
       it('should create JWT with null keyFile', function (done) {
         var json = createJwtJSON();
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         auth.fromJSON(json, function (err, result) {
           assert.equal(null, err);
           assert.equal(null, result.keyFile);
@@ -212,7 +212,7 @@ describe('googleAuth', function() {
     });
     describe('Refresh token', function() {
       it('should error on empty json', function (done) {
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT();
         jwt.fromJSON({}, function (err) {
           assert.equal(true, err instanceof Error);
@@ -224,7 +224,7 @@ describe('googleAuth', function() {
         var json = createRefreshJSON();
         delete json.client_id;
 
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT();
         jwt.fromJSON(json, function (err) {
           assert.equal(true, err instanceof Error);
@@ -236,7 +236,7 @@ describe('googleAuth', function() {
         var json = createRefreshJSON();
         delete json.client_secret;
 
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT();
         jwt.fromJSON(json, function (err) {
           assert.equal(true, err instanceof Error);
@@ -248,7 +248,7 @@ describe('googleAuth', function() {
         var json = createRefreshJSON();
         delete json.refresh_token;
 
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT();
         jwt.fromJSON(json, function (err) {
           assert.equal(true, err instanceof Error);
@@ -261,7 +261,7 @@ describe('googleAuth', function() {
   describe('.fromStream', function () {
 
     it('should error on null stream', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromStream(null, function (err) {
         assert.equal(true, err instanceof Error);
         done();
@@ -277,7 +277,7 @@ describe('googleAuth', function() {
       var stream = fs.createReadStream('./test/fixtures/private.json');
 
       // And pass it into the fromStream method.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromStream(stream, function (err, result) {
         assert.equal(null, err);
 
@@ -301,7 +301,7 @@ describe('googleAuth', function() {
       var stream = fs.createReadStream('./test/fixtures/refresh.json');
 
       // And pass it into the fromStream method.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromStream(stream, function (err, result) {
         assert.ifError(err);
 
@@ -318,7 +318,7 @@ describe('googleAuth', function() {
   describe('._getApplicationCredentialsFromFilePath', function () {
 
     it('should error on null file path', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath(null, function (err) {
         assert.equal(true, err instanceof Error);
         done();
@@ -326,7 +326,7 @@ describe('googleAuth', function() {
     });
 
     it('should error on empty file path', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath('', function (err) {
         assert.equal(true, err instanceof Error);
         done();
@@ -334,7 +334,7 @@ describe('googleAuth', function() {
     });
 
     it('should error on non-string file path', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath(2, function (err) {
         assert.equal(true, err instanceof Error);
         done();
@@ -342,7 +342,7 @@ describe('googleAuth', function() {
     });
 
     it('should error on invalid file path', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath('./nonexistantfile.json',
         function (err) {
 
@@ -357,7 +357,7 @@ describe('googleAuth', function() {
       assert.equal(true, fs.lstatSync(directory).isDirectory());
 
       // Execute.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath(directory,
         function (err) {
 
@@ -368,7 +368,7 @@ describe('googleAuth', function() {
 
     it('should handle errors thrown from createReadStream', function (done) {
       // Set up a mock to throw from the createReadStream method.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._createReadStream = function () {
         throw new Error('Hans and Chewbacca');
       };
@@ -383,7 +383,7 @@ describe('googleAuth', function() {
 
     it('should handle errors thrown from fromStream', function (done) {
       // Set up a mock to throw from the fromStream method.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromStream = function () {
         throw new Error('Darth Maul');
       };
@@ -398,7 +398,7 @@ describe('googleAuth', function() {
 
     it('should handle errors passed from fromStream', function (done) {
       // Set up a mock to return an error from the fromStream method.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth.fromStream = function (stream, callback) {
         callback(new Error('Princess Leia'));
       };
@@ -417,7 +417,7 @@ describe('googleAuth', function() {
       var json = JSON.parse(fileContents);
 
       // Now pass the same path to the auth loader.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath('./test/fixtures/private.json',
         function (err, result) {
 
@@ -436,7 +436,7 @@ describe('googleAuth', function() {
 
     it('should return false when env var is not set', function (done) {
       // Set up a mock to return a null path string.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       insertEnvironmentVariableIntoAuth(auth, 'GOOGLE_APPLICATION_CREDENTIALS', null);
 
       // The test ends successfully after 1 step has completed.
@@ -453,7 +453,7 @@ describe('googleAuth', function() {
 
     it('should return false when env var is empty string', function (done) {
       // Set up a mock to return an empty path string.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       insertEnvironmentVariableIntoAuth(auth, 'GOOGLE_APPLICATION_CREDENTIALS', '');
 
       // The test ends successfully after 1 step has completed.
@@ -470,7 +470,7 @@ describe('googleAuth', function() {
 
     it('should handle invalid environment variable', function (done) {
       // Set up a mock to return a path to an invalid file.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       insertEnvironmentVariableIntoAuth(auth, 'GOOGLE_APPLICATION_CREDENTIALS',
         './nonexistantfile.json');
 
@@ -489,7 +489,7 @@ describe('googleAuth', function() {
 
     it('should handle valid environment variable', function (done) {
       // Set up a mock to return path to a valid credentials file.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       insertEnvironmentVariableIntoAuth(auth, 'GOOGLE_APPLICATION_CREDENTIALS',
         './test/fixtures/private.json');
 
@@ -523,7 +523,7 @@ describe('googleAuth', function() {
       var correctLocation = false;
 
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
       auth._pathJoin = pathJoin;
@@ -547,7 +547,7 @@ describe('googleAuth', function() {
       var correctLocation = false;
 
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'HOME', 'foo');
       auth._pathJoin = pathJoin;
@@ -570,7 +570,7 @@ describe('googleAuth', function() {
 
     it('should fail on Windows when APPDATA is not defined', function (done) {
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', null);
       auth._pathJoin = pathJoin;
@@ -592,7 +592,7 @@ describe('googleAuth', function() {
 
     it('should fail on non-Windows when HOME is not defined', function (done) {
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'HOME', null);
       auth._pathJoin = pathJoin;
@@ -614,7 +614,7 @@ describe('googleAuth', function() {
 
     it('should fail on Windows when file does not exist', function (done) {
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
       auth._pathJoin = pathJoin;
@@ -636,7 +636,7 @@ describe('googleAuth', function() {
 
     it('should fail on non-Windows when file does not exist', function (done) {
       // Set up mocks.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'HOME', 'foo');
       auth._pathJoin = pathJoin;
@@ -659,7 +659,7 @@ describe('googleAuth', function() {
 
   it('should succeeds on Windows', function (done) {
     // Set up mocks.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     blockGoogleApplicationCredentialEnvironmentVariable(auth);
     insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
     auth._pathJoin = pathJoin;
@@ -686,7 +686,7 @@ describe('googleAuth', function() {
 
   it('should succeeds on non-Windows', function (done) {
     // Set up mocks.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     blockGoogleApplicationCredentialEnvironmentVariable(auth);
     insertEnvironmentVariableIntoAuth(auth, 'HOME', 'foo');
     auth._pathJoin = pathJoin;
@@ -713,7 +713,7 @@ describe('googleAuth', function() {
 
   it('should pass along a failure on Windows', function (done) {
     // Set up mocks.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     blockGoogleApplicationCredentialEnvironmentVariable(auth);
     insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
     auth._pathJoin = pathJoin;
@@ -740,7 +740,7 @@ describe('googleAuth', function() {
 
   it('should pass along a failure on non-Windows', function (done) {
     // Set up mocks.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     blockGoogleApplicationCredentialEnvironmentVariable(auth);
     insertEnvironmentVariableIntoAuth(auth, 'HOME', 'foo');
     auth._pathJoin = pathJoin;
@@ -784,7 +784,7 @@ describe('googleAuth', function() {
         };
 
         // Set up a new GoogleAuth and prepare it for local environment variable handling.
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         setUpAuthForEnvironmentVariable(auth);
 
         // Ask for credentials, the first time.
@@ -818,7 +818,7 @@ describe('googleAuth', function() {
 
             // Now create a second GoogleAuth instance, and ask for credentials. We should
             // get a new credentials instance this time.
-            var auth2 = new googleAuth();
+            var auth2 = new GoogleAuth();
             setUpAuthForEnvironmentVariable(auth2);
 
             // Step 2 has completed.
@@ -848,7 +848,7 @@ describe('googleAuth', function() {
       // * Environment variable is set up to point to private.json
       // * Well-known file is set up to point to private2.json
       // * Running on GCE is set to true.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       insertEnvironmentVariableIntoAuth(auth, 'GOOGLE_APPLICATION_CREDENTIALS',
         './test/fixtures/private.json');
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
@@ -880,7 +880,7 @@ describe('googleAuth', function() {
       // * Environment variable is not set.
       // * Well-known file is set up to point to private2.json
       // * Running on GCE is set to true.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
       auth._pathJoin = pathJoin;
@@ -907,7 +907,7 @@ describe('googleAuth', function() {
       // * Environment variable is not set.
       // * Well-known file is not set.
       // * Running on GCE is set to true.
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       blockGoogleApplicationCredentialEnvironmentVariable(auth);
       insertEnvironmentVariableIntoAuth(auth, 'APPDATA', 'foo');
       auth._pathJoin = pathJoin;
@@ -929,7 +929,7 @@ describe('googleAuth', function() {
   describe('._checkIsGCE', function () {
 
     it('should set the _isGCE flag when running on GCE', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
 
       // Mock the transport layer to return the correct header indicating that
       // we're running on GCE.
@@ -950,7 +950,7 @@ describe('googleAuth', function() {
     });
 
     it('should not set the _isGCE flag when not running on GCE', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
 
       // Mock the transport layer to indicate that we're not running on GCE.
       auth.transporter = new MockTransporter(false);
@@ -970,7 +970,7 @@ describe('googleAuth', function() {
     });
 
     it('Does not execute the second time when running on GCE', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
 
       // Mock the transport layer to indicate that we're not running on GCE.
       auth.transporter = new MockTransporter(true);
@@ -1001,7 +1001,7 @@ describe('googleAuth', function() {
     });
 
     it('Does not execute the second time when not running on GCE', function (done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
 
       // Mock the transport layer to indicate that we're not running on GCE.
       auth.transporter = new MockTransporter(false);
@@ -1031,7 +1031,7 @@ describe('googleAuth', function() {
       });
 
       it('Returns false on transport error', function (done) {
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
 
         // Mock the transport layer to indicate that we're not running on GCE, but also to
         // throw an error.

--- a/test/test.iam.js
+++ b/test/test.iam.js
@@ -17,14 +17,14 @@
 'use strict';
 
 var assert = require('assert');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 
 describe('.getRequestMetadata', function() {
   var test_selector = 'a-test-selector';
   var test_token = 'a-test-token';
   var client;
   beforeEach(function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     client = new auth.IAMAuth(test_selector, test_token);
   });
 

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var fs = require('fs');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var jws = require('jws');
 var keypair = require('keypair');
 var nock = require('nock');
@@ -41,7 +41,7 @@ describe('Initial credentials', function() {
   it('should create a dummy refresh token string', function () {
     // It is important that the compute client is created with a refresh token value filled
     // in, or else the rest of the logic will not work.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var jwt = new auth.JWT();
     assert.equal('jwt-placeholder', jwt.credentials.refresh_token);
   });
@@ -53,7 +53,7 @@ describe('JWT auth client', function() {
   describe('.authorize', function() {
 
     it('should get an initial access token', function(done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -83,7 +83,7 @@ describe('JWT auth client', function() {
     });
 
     it('should accept scope as string', function(done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -109,7 +109,7 @@ describe('JWT auth client', function() {
     describe('when scopes are set', function() {
 
       it('can get obtain new access token', function(done) {
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT(
             'foo@serviceaccount.com',
             '/path/to/key.pem',
@@ -144,7 +144,7 @@ describe('JWT auth client', function() {
     describe('when scopes are set', function() {
 
       it('can obtain new access token', function(done) {
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT(
             'foo@serviceaccount.com',
             '/path/to/key.pem',
@@ -182,7 +182,7 @@ describe('JWT auth client', function() {
       it('gets a jwt header access token', function(done) {
         var keys = keypair(1024 /* bitsize of private key */);
         var email = 'foo@serviceaccount.com';
-        var auth = new googleAuth();
+        var auth = new GoogleAuth();
         var jwt = new auth.JWT(
             'foo@serviceaccount.com',
             null,
@@ -216,7 +216,7 @@ describe('JWT auth client', function() {
   describe('.request', function() {
 
     it('should refresh token if missing access token', function(done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -241,7 +241,7 @@ describe('JWT auth client', function() {
     });
 
     it('should refresh token if expired', function(done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -273,7 +273,7 @@ describe('JWT auth client', function() {
           .post('/o/oauth2/token', '*')
           .reply(200, { access_token: 'abc123', expires_in: 10000 });
 
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -301,7 +301,7 @@ describe('JWT auth client', function() {
           .post('/o/oauth2/token', '*')
           .reply(200, { access_token: 'abc123', expires_in: 10000 });
 
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
           'foo@serviceaccount.com',
           '/path/to/key.pem',
@@ -325,7 +325,7 @@ describe('JWT auth client', function() {
   });
 
   it('should return expiry_date in milliseconds', function(done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var jwt = new auth.JWT(
         'foo@serviceaccount.com',
         '/path/to/key.pem',
@@ -358,7 +358,7 @@ describe('.createScoped', function() {
   // set up the auth module.
   var auth;
   beforeEach(function() {
-    auth = new googleAuth();
+    auth = new GoogleAuth();
   });
 
   it('should clone stuff', function() {
@@ -457,7 +457,7 @@ describe('.createScopedRequired', function() {
   // set up the auth module.
   var auth;
   beforeEach(function() {
-    auth = new googleAuth();
+    auth = new GoogleAuth();
   });
 
   it('should return true when scopes is null', function () {
@@ -505,7 +505,7 @@ describe('.createScopedRequired', function() {
   });
 
   it('should return false when scopes is a filled-in array', function () {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var jwt = new auth.JWT(
       'foo@serviceaccount.com',
       '/path/to/key.pem',
@@ -519,7 +519,7 @@ describe('.createScopedRequired', function() {
   it('should return false when scopes is not an array or a string, but can be used as a string',
     function () {
 
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var jwt = new auth.JWT(
         'foo@serviceaccount.com',
         '/path/to/key.pem',
@@ -536,7 +536,7 @@ describe('.fromJson', function () {
   var jwt, json;
   beforeEach(function() {
     json = createJSON();
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     jwt = new auth.JWT();
   });
 
@@ -618,7 +618,7 @@ describe('.fromStream', function () {
   // set up the jwt instance being tested.
   var jwt;
   beforeEach(function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     jwt = new auth.JWT();
   });
 

--- a/test/test.jwtaccess.js
+++ b/test/test.jwtaccess.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var fs = require('fs');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var keypair = require('keypair');
 var jws = require('jws');
 
@@ -40,7 +40,7 @@ describe('.getRequestMetadata', function() {
     var keys = keypair(1024 /* bitsize of private key */);
     var testUri = 'http:/example.com/my_test_service';
     var email = 'foo@serviceaccount.com';
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var client = new auth.JWTAccess(email, keys['private']);
 
     var retValue = 'dummy';
@@ -63,7 +63,7 @@ describe('.getRequestMetadata', function() {
 describe('.createScopedRequired', function() {
 
   it('should return false', function () {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var client = new auth.JWTAccess(
       'foo@serviceaccount.com',
       null);
@@ -78,7 +78,7 @@ describe('.fromJson', function () {
   var json, client;
   beforeEach(function() {
     json = createJSON();
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     client = new auth.JWTAccess();
   });
 
@@ -136,7 +136,7 @@ describe('.fromStream', function () {
   // set up the client instance being tested.
   var client;
   beforeEach(function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     client = new auth.JWTAccess();
   });
 

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -20,7 +20,7 @@ var url = require('url');
 var assert = require('assert');
 var qs = require('querystring');
 var fs = require('fs');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var crypto = require('crypto');
 var nock = require('nock');
 var AuthClient = require('../lib/auth/authclient.js');
@@ -43,7 +43,7 @@ describe('OAuth2 client', function() {
       response_type: 'code token'
     };
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl(opts);
     var parsed = url.parse(generated);
@@ -71,7 +71,7 @@ describe('OAuth2 client', function() {
       response_type: 'code token'
     };
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl(opts);
     var parsed = url.parse(generated);
@@ -83,7 +83,7 @@ describe('OAuth2 client', function() {
 
   it('should set response_type param to code if none is given while' +
       'generating the consent page url', function(done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl();
     var parsed = url.parse(generated);
@@ -96,7 +96,7 @@ describe('OAuth2 client', function() {
   // jason: keep
   /*
   it('should return err no access or refresh token is set before making a request', function(done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new googleapis.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     new googleapis.GoogleApis()
       .urlshortener('v1').url.get({ shortUrl: '123', auth: oauth2client }, function(err, result) {
@@ -166,7 +166,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var login = oauth2client.verifySignedJwtWithCerts(data,
         {keyid: publicKey}, 'testaudience');
@@ -210,7 +210,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -258,7 +258,7 @@ describe('OAuth2 client', function() {
     //Originally: data += '.'+signature;
     data += signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -309,7 +309,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -360,7 +360,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -404,7 +404,7 @@ describe('OAuth2 client', function() {
       '.' + new Buffer(idToken).toString('base64') +
       '.' + 'broken-signature';
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -452,7 +452,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -502,7 +502,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -552,7 +552,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -603,7 +603,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.verifySignedJwtWithCerts(
       data,
@@ -652,7 +652,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -704,7 +704,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -754,7 +754,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(
       function() {
@@ -805,7 +805,7 @@ describe('OAuth2 client', function() {
 
     data += '.' + signature;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.verifySignedJwtWithCerts(
       data,
@@ -821,7 +821,7 @@ describe('OAuth2 client', function() {
     var scope = nock('https://www.googleapis.com')
       .get('/oauth2/v1/certs')
       .replyWithFile(200, __dirname + '/fixtures/oauthcerts.json');
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.getFederatedSignonCerts(function(err, certs) {
       assert.equal(err, null);
@@ -842,7 +842,7 @@ describe('OAuth2 client', function() {
           .get('/oauth2/v1/certs')
           .once()
           .replyWithFile(200, __dirname + '/fixtures/oauthcerts.json');
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.getFederatedSignonCerts(function(err, certs) {
         assert.equal(err, null);
@@ -859,7 +859,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should set redirect_uri if not provided in options', function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl({});
     var parsed = url.parse(generated);
@@ -868,7 +868,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should set client_id if not provided in options', function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl({});
     var parsed = url.parse(generated);
@@ -877,7 +877,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should override redirect_uri if provided in options', function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl({ redirect_uri: 'overridden' });
     var parsed = url.parse(generated);
@@ -886,7 +886,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should override client_id if provided in options', function() {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     var generated = oauth2client.generateAuthUrl({ client_id: 'client_override' });
     var parsed = url.parse(generated);
@@ -895,7 +895,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should return error in callback on request', function(done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.request({}, function(err, result) {
       assert.equal(err.message, 'No access or refresh token is set.');
@@ -905,7 +905,7 @@ describe('OAuth2 client', function() {
   });
 
   it('should return error in callback on refreshAccessToken', function(done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.refreshAccessToken(function(err, result) {
       assert.equal(err.message, 'No refresh token is set.');
@@ -996,7 +996,7 @@ describe('OAuth2 client', function() {
       var scope = nock('https://accounts.google.com')
           .get('/o/oauth2/revoke?token=abc')
           .reply(200, { success: true });
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.credentials = { access_token: 'abc', refresh_token: 'abc' };
       oauth2client.revokeCredentials(function(err, result) {
@@ -1009,7 +1009,7 @@ describe('OAuth2 client', function() {
     });
 
     it('should clear credentials and return error if no access token to revoke', function(done) {
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.credentials = { refresh_token: 'abc' };
       oauth2client.revokeCredentials(function(err, result) {
@@ -1027,7 +1027,7 @@ describe('OAuth2 client', function() {
       var scope = nock('https://accounts.google.com')
           .post('/o/oauth2/token')
           .reply(200, { access_token: 'abc', refresh_token: '123', expires_in: 10 });
-      var auth = new googleAuth();
+      var auth = new GoogleAuth();
       var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.getToken('code here', function(err, tokens) {
         assert(tokens.expiry_date >= now + (10 * 1000));

--- a/test/test.refresh.js
+++ b/test/test.refresh.js
@@ -17,7 +17,7 @@
 'use strict';
 
 var assert = require('assert');
-var googleAuth = require('../lib/auth/googleauth.js');
+var GoogleAuth = require('../lib/auth/googleauth.js');
 var nock = require('nock');
 var fs = require('fs');
 
@@ -40,7 +40,7 @@ describe('Refresh Token auth client', function() {
 describe('.fromJson', function () {
 
   it('should error on null json', function (done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(null, function (err) {
       assert.equal(true, err instanceof Error);
@@ -49,7 +49,7 @@ describe('.fromJson', function () {
   });
 
   it('should error on empty json', function (done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON({}, function (err) {
       assert.equal(true, err instanceof Error);
@@ -61,7 +61,7 @@ describe('.fromJson', function () {
     var json = createJSON();
     delete json.client_id;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.equal(true, err instanceof Error);
@@ -73,7 +73,7 @@ describe('.fromJson', function () {
     var json = createJSON();
     delete json.client_secret;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.equal(true, err instanceof Error);
@@ -85,7 +85,7 @@ describe('.fromJson', function () {
     var json = createJSON();
     delete json.refresh_token;
 
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.equal(true, err instanceof Error);
@@ -95,7 +95,7 @@ describe('.fromJson', function () {
 
   it('should create UserRefreshClient with clientId_', function(done) {
     var json = createJSON();
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.ifError(err);
@@ -106,7 +106,7 @@ describe('.fromJson', function () {
 
   it('should create UserRefreshClient with clientSecret_', function(done) {
     var json = createJSON();
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.ifError(err);
@@ -117,7 +117,7 @@ describe('.fromJson', function () {
 
   it('should create UserRefreshClient with _refreshToken', function(done) {
     var json = createJSON();
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromJSON(json, function (err) {
       assert.ifError(err);
@@ -130,7 +130,7 @@ describe('.fromJson', function () {
 describe('.fromStream', function () {
 
   it('should error on null stream', function (done) {
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromStream(null, function (err) {
       assert.equal(true, err instanceof Error);
@@ -147,7 +147,7 @@ describe('.fromStream', function () {
     var stream = fs.createReadStream('./test/fixtures/refresh.json');
 
     // And pass it into the fromStream method.
-    var auth = new googleAuth();
+    var auth = new GoogleAuth();
     var refresh = new auth.UserRefreshClient();
     refresh.fromStream(stream, function (err) {
       assert.ifError(err);


### PR DESCRIPTION
This fixes #78. Note that all of these changes except the one in `googleauth.js` are in test files, and none of these changes has any effect on the API surface