### PR TITLE
Medium severity vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gtoken": "^1.1.0",
     "lodash.noop": "~3.0.0",
     "jws": "~3.0.0",
-    "request": "~2.60.0",
+    "request": "~2.72.0",
     "string-template": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Please update request:

✗ Medium severity vulnerability found on request@2.60.0
- desc: Remote Memory Exposure
- info: https://snyk.io/vuln/npm:request:20160119
- from: myproject > googleapis@7.1.0 > google-auth-library@0.9.8 > request@2.60.0
Your dependencies are out of date, otherwise you would be using a newer request than request@2.60.0.

https://snyk.io/vuln/npm:request:20160119