### PR TITLE
Handle symlinks to default application credentials

### DIFF
--- a/lib/auth/googleauth.js
+++ b/lib/auth/googleauth.js
@@ -260,9 +260,13 @@ GoogleAuth.prototype._getApplicationCredentialsFromFilePath =
     if (!filePath || filePath.length === 0) {
       error = new Error('The file path is invalid.');
     }
+
     // Make sure there is a file at the path. lstatSync will throw if there is nothing there.
     if (!error) {
       try {
+        // Resolve path to actual file in case of symlink. Expect a thrown error if not resolvable.
+        filePath = fs.realpathSync(filePath);
+
         if (!fs.lstatSync(filePath).isFile()) {
           throw '';
         }

--- a/test/fixtures/badlink
+++ b/test/fixtures/badlink
@@ -1,0 +1,1 @@
+./noexists.json

--- a/test/fixtures/emptylink
+++ b/test/fixtures/emptylink
@@ -1,0 +1,1 @@
+./empty.json

--- a/test/fixtures/goodlink
+++ b/test/fixtures/goodlink
@@ -1,0 +1,1 @@
+./private.json

--- a/test/test.googleauth.js
+++ b/test/test.googleauth.js
@@ -317,6 +317,30 @@ describe('GoogleAuth', function() {
 
   describe('._getApplicationCredentialsFromFilePath', function () {
 
+    it('should not error on valid symlink', function (done) {
+      var auth = new GoogleAuth();
+      auth._getApplicationCredentialsFromFilePath('./test/fixtures/goodlink', function (err) {
+        assert.equal(false, err instanceof Error);
+        done();
+      });
+    });
+
+    it('should error on invalid symlink', function (done) {
+      var auth = new GoogleAuth();
+      auth._getApplicationCredentialsFromFilePath('./test/fixtures/badlink', function (err) {
+        assert.equal(true, err instanceof Error);
+        done();
+      });
+    });
+
+    it('should error on valid link to invalid data', function (done) {
+      var auth = new GoogleAuth();
+      auth._getApplicationCredentialsFromFilePath('./test/fixtures/emptylink', function (err) {
+        assert.equal(true, err instanceof Error);
+        done();
+      });
+    });
+
     it('should error on null file path', function (done) {
       var auth = new GoogleAuth();
       auth._getApplicationCredentialsFromFilePath(null, function (err) {


### PR DESCRIPTION
When using Kubernetes 1.3 secrets with Node.js the secret volume can be
a symbolic link to the credentials file. Previously, this would throw an
error due to the assertion of lstat.isFile(). This patch adds real path
resolution prior to asserting that filePath points to valid file.