### PR TITLE
googleauth.js change JWT constructor call

### DIFF
--- a/lib/auth/googleauth.js
+++ b/lib/auth/googleauth.js
@@ -301,7 +301,7 @@ GoogleAuth.prototype.fromJSON = function(json, opt_callback) {
   if (json.type === 'authorized_user') {
     client = new that.UserRefreshClient();
   } else {
-    client = new that.JWTClient();
+    client = new that.JWT();
   }
   client.fromJSON(json, function(err) {
     if (err) {


### PR DESCRIPTION
Given the following code with a valid path for `keyfilePath`:

```JS
var keyfilePath = './path/to/my/keyfile.json';
var stream = require('fs').createReadStream(keyFilePath);
var GoogleAuth = require('google-auth-library');
var ga = new GoogleAuth();

ga.fromStream(keyfilePath, function (err, result){
  if (err) {
    console.error('error:', err);
  } else {
    console.log('result:', result);
  }
});
```

I would expect to see that error is empty but I actually get:

```JS
TypeError: that.JWTClient is not a constructor
    at GoogleAuth.fromJSON (/Users/cristiancavall/googlesrc/cloud-diagnostics-common-nodejs/node_modules/google-auth-library/lib/auth/googleauth.js:306:17)
    at ReadStream.<anonymous> (/Users/cristiancavall/googlesrc/cloud-diagnostics-common-nodejs/node_modules/google-auth-library/lib/auth/googleauth.js:344:12)
    at emitNone (events.js:91:20)
    at ReadStream.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:975:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Code in question:

```JS
if (json.type === 'authorized_user') {
  client = new that.UserRefreshClient();
} else {
  client = new that.JWTClient();
}
```

Solution: Use the constructor stored in the prototype

```JS
/**
 * Convenience field mapping in the JWT credential type.
 */
GoogleAuth.prototype.JWT = require('./jwtclient.js');

/* ... */

if (json.type === 'authorized_user') {
  client = new that.UserRefreshClient();
} else {
  client = new that.JWT();
}
```