### PR TITLE
Prepare for 0.9.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.10 (11/15/2016)
+
+### Changes
+
+* Detect project ID from default application credentials ([@jmdobry][])
+
 ## 0.9.9 (10/14/2016)
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-auth-library",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "contributors": [


### PR DESCRIPTION
@tbetbetbe would you be able to do a release to npm? The google-cloud-node library needs this release for detecting a project ID in DAC environments. Hopefully this makes it easier!