### PR TITLE
Specify minimum request@2.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gtoken": "^1.1.0",
     "lodash.noop": "^3.0.0",
     "jws": "^3.1.0",
-    "request": "^2.74.0",
+    "request": "^2.79.0",
     "string-template": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This uses the uuid module, as node-uuid is deprecated

Support is dropped for node@0.10, but that's EOL anyway (and already in your semver range)

https://github.com/request/request/blob/master/CHANGELOG.md