### PR TITLE
Add API key support to Google-Auth-Library

### DIFF
--- a/lib/auth/googleauth.js
+++ b/lib/auth/googleauth.js
@@ -517,6 +517,22 @@ GoogleAuth.prototype.fromStream = function(stream, opt_callback) {
 };
 
 /**
+ * Create a credentials instance using the given API key string.
+ * @param {string} - The API key string
+ * @param {function=} - Optional callback function
+ */
+GoogleAuth.prototype.fromAPIKey = function (apiKey, opt_callback) {
+  var client = new this.JWTClient();
+  client.fromAPIKey(apiKey, function (err) {
+    if (err) {
+      callback(opt_callback, err);
+    } else {
+      callback(opt_callback, null, client);
+    }
+  });
+};
+
+/**
  * Determines whether the current operating system is Windows.
  * @api private
  * */

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -20,6 +20,7 @@ var Auth2Client = require('./oauth2client.js');
 var gToken = require('gtoken');
 var JWTAccess = require('./jwtaccess.js');
 var noop = require('lodash.noop');
+var isString = require('lodash.isstring');
 var util = require('util');
 
 
@@ -205,6 +206,25 @@ JWT.prototype.fromStream = function(stream, opt_callback) {
       done(err);
     }
   });
+};
+
+/**
+ * Creates a JWT credentials instance using an API Key for authentication.
+ * @param {string} apiKey - the API Key in string form.
+ * @param {function=} opt_callback - Optional callback to be invoked after
+ *  initialization.
+ */
+JWT.prototype.fromAPIKey = function (apiKey, opt_callback) {
+  var done = opt_callback || noop;
+
+  if (!isString(apiKey)) {
+    setImmediate(function () {
+      done(new Error('Must provide an API Key string.'));
+    });
+    return;
+  }
+  this.setAPIKey(apiKey);
+  done(null);
 };
 
 /**

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -22,6 +22,7 @@ var noop = require('lodash.noop');
 var PemVerifier = require('./../pemverifier.js');
 var querystring = require('querystring');
 var util = require('util');
+var merge = require('lodash.merge');
 
 var certificateCache = null;
 var certificateExpiry = null;
@@ -43,6 +44,7 @@ function OAuth2Client(clientId, clientSecret, redirectUri, opt_opts) {
   this.redirectUri_ = redirectUri;
   this.opts = opt_opts || {};
   this.credentials = {};
+  this.apiKey = null;
 }
 
 /**
@@ -267,8 +269,9 @@ OAuth2Client.prototype.getRequestMetadata = function(opt_uri, metadataCb) {
   var that = this;
   var thisCreds = this.credentials;
 
-  if (!thisCreds.access_token && !thisCreds.refresh_token) {
-    return metadataCb(new Error('No access or refresh token is set.'), null);
+  if (!thisCreds.access_token && !thisCreds.refresh_token && !this.apiKey) {
+    return metadataCb(new Error('No access, refresh token or API key is set.'),
+      null);
   }
 
   // if no expiry time, assume it's not expired
@@ -278,7 +281,11 @@ OAuth2Client.prototype.getRequestMetadata = function(opt_uri, metadataCb) {
   if (thisCreds.access_token && !isTokenExpired) {
     thisCreds.token_type = thisCreds.token_type || 'Bearer';
     var headers = {'Authorization': thisCreds.token_type + ' ' + thisCreds.access_token };
-    return metadataCb(null, headers , null);
+    return metadataCb(null, headers, null);
+  }
+
+  if (this.apiKey) {
+    return metadataCb(null, {}, null);
   }
 
   return this.refreshToken_(thisCreds.refresh_token, function(err, tokens, response) {
@@ -297,6 +304,15 @@ OAuth2Client.prototype.getRequestMetadata = function(opt_uri, metadataCb) {
       return metadataCb(err, headers , response);
     }
   });
+};
+
+/**
+ * Sets the given value as the value of the apiKey
+ * property on the client instance.
+ * @param {string} apiKey - the apiKey to use for authentication
+ */
+OAuth2Client.prototype.setAPIKey = function (apiKey) {
+  this.apiKey = apiKey;
 };
 
 /**
@@ -370,6 +386,13 @@ OAuth2Client.prototype.request = function(opts, callback) {
       if (headers) {
         opts.headers = opts.headers || {};
         opts.headers.Authorization = headers.Authorization;
+      }
+      if (that.apiKey) {
+        if (opts.qs) {
+          opts.qs = merge({}, opts.qs, {key: that.apiKey});
+        } else {
+          opts.qs = {key: that.apiKey};
+        }
       }
       return that._makeRequest(opts, postRequestCb);
     }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   ],
   "dependencies": {
     "gtoken": "^1.2.1",
-    "lodash.noop": "^3.0.1",
     "jws": "^3.1.4",
+    "lodash.isstring": "^4.0.1",
+    "lodash.merge": "^4.6.0",
+    "lodash.noop": "^3.0.1",
     "request": "^2.74.0"
   },
   "devDependencies": {

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -686,3 +686,36 @@ describe('.fromStream', function () {
   });
 
 });
+
+describe('.fromAPIKey', function () {
+  var jwt;
+  var KEY = 'test';
+  beforeEach(function () {
+    var auth = new GoogleAuth();
+    jwt = new auth.JWT();
+  });
+  describe('exception behaviour', function () {
+    it('should error without api key', function (done) {
+      jwt.fromAPIKey(undefined, function (err) {
+        assert(err instanceof Error);
+        done();
+      });
+    });
+    it('should error with invalid api key type', function (done) {
+      jwt.fromAPIKey({key: KEY}, function (err) {
+        assert(err instanceof Error);
+        done();
+      });
+    });
+  });
+  describe('Valid behaviour', function () {
+    
+    it('should set the .apiKey property on the instance', function (done) {
+      jwt.fromAPIKey(KEY, function (err) {
+        assert.strictEqual(jwt.apiKey, KEY);
+        assert.strictEqual(err, null);
+        done();
+      });
+    });
+  });
+});

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -948,7 +948,7 @@ describe('OAuth2 client', function() {
     var auth = new GoogleAuth();
     var oauth2client = new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.request({}, function(err, result) {
-      assert.equal(err.message, 'No access or refresh token is set.');
+      assert.equal(err.message, 'No access, refresh token or API key is set.');
       assert.equal(result, null);
       done();
     });


### PR DESCRIPTION
Add fromAPIKey method to jwtClient and supporting
logic in oauth2client.js. Applying an API key to
an instance of the oauth2client will bypass token
checking/refresh and append the given API key as
a query string to each request made from the
instance in the following form:

```JS
`{target_base_url}?key={given_key}`
```