### PR TITLE
Remove lodash.noop lib dependency

### DIFF
--- a/lib/auth/jwtaccess.js
+++ b/lib/auth/jwtaccess.js
@@ -17,7 +17,7 @@
 'use strict';
 
 var jws = require('jws');
-var noop = require('lodash.noop');
+var noop = Function.prototype;
 
 /**
  * JWTAccess service account credentials.

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -19,7 +19,7 @@
 var Auth2Client = require('./oauth2client.js');
 var gToken = require('gtoken');
 var JWTAccess = require('./jwtaccess.js');
-var noop = require('lodash.noop');
+var noop = Function.prototype;
 var isString = require('lodash.isstring');
 var util = require('util');
 

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -18,7 +18,7 @@
 
 var AuthClient = require('./authclient.js');
 var LoginTicket = require('./loginticket.js');
-var noop = require('lodash.noop');
+var noop = Function.prototype;
 var PemVerifier = require('./../pemverifier.js');
 var querystring = require('querystring');
 var util = require('util');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jws": "^3.1.4",
     "lodash.isstring": "^4.0.1",
     "lodash.merge": "^4.6.0",
-    "lodash.noop": "^3.0.1",
     "request": "^2.74.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,10 +756,6 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.noop@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-3.0.1.tgz#38188f4d650a3a474258439b96ec45b32617133c"
-
 lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"


### PR DESCRIPTION
Lodash noop lib is useless and it's better to use just:
```js
var noop = Function;
```

Because of following reasons:
* It's shorter
* It's faster
* It doesn't take space in node_modules
* It will not fail in case of deletion of lodash.noop
* It will not take space in package.json and yarn.lock
* Even lodash devs removed lodash.noop from their code.