### PR TITLE
added input validation to idToken in verifyIdToken

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -437,6 +437,10 @@ OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
       'an ID Token and a callback method');
   }
 
+  if((typeof idToken) !=='string'){
+    throw new Error('The ID Token has to be a string');
+  }
+
   this.getFederatedSignonCerts(function(err, certs) {
     if (err) {
       callback(err, null);

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -23,6 +23,7 @@ var PemVerifier = require('./../pemverifier.js');
 var querystring = require('querystring');
 var util = require('util');
 var merge = require('lodash.merge');
+var isString = require('lodash.isstring');
 
 var certificateCache = null;
 var certificateExpiry = null;
@@ -437,7 +438,7 @@ OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
       'an ID Token and a callback method');
   }
 
-  if((typeof idToken) !=='string'){
+  if(!isString(idToken)){
     throw new Error('The ID Token has to be a string');
   }
 


### PR DESCRIPTION
Gives a meaningful error message when the ID Token is not a string. In the old version there was just an exception in Line 519: jwt.split is not a function.