### PR TITLE
Add official tslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "lint": "tslint -c tslint.json ts/**/*.ts",
+    "lint": "tslint --type-check -p tsconfig.json -c tslint.json ts/**/*.ts",
     "mocha": "mocha --reporter spec --timeout 4000 --require source-map-support/register",
     "generate-docs": "typedoc --name 'Google Node.js OAuth 2.0 Client' --out docs --readme README.md ts/lib",
     "coverage": "istanbul cover -x 'apis/**' _mocha -- --reporter spec --timeout 4000",

--- a/ts/lib/auth/computeclient.ts
+++ b/ts/lib/auth/computeclient.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as util from 'util';
 import Auth2Client from './oauth2client';
 
 export default class Compute extends Auth2Client {

--- a/ts/lib/auth/oauth2client.ts
+++ b/ts/lib/auth/oauth2client.ts
@@ -19,7 +19,6 @@ import LoginTicket from './loginticket';
 import PemVerifier from './../pemverifier';
 import { merge } from 'lodash';
 import * as querystring from 'querystring';
-import * as util from 'util';
 const noop = Function.prototype;
 
 export default class OAuth2Client extends AuthClient {
@@ -339,6 +338,7 @@ export default class OAuth2Client extends AuthClient {
         retry = false;
         // Force token refresh
         this.refreshAccessToken(() => {
+          // tslint:disable-next-line:no-use-before-declare
           this.getRequestMetadata(unusedUri, authCb);
         });
       } else {

--- a/ts/lib/auth/oauth2client.ts
+++ b/ts/lib/auth/oauth2client.ts
@@ -323,6 +323,10 @@ export default class OAuth2Client extends AuthClient {
     // Callbacks will close over this to ensure that we only retry once
     let retry = true;
     const unusedUri = null;
+    
+    // Declare authCb upfront to avoid the linter complaining about use before
+    // declaration.
+    let authCb;
 
     // Hook the callback routine to call the _postRequest method.
     const postRequestCb = (err, body, resp) => {
@@ -338,7 +342,6 @@ export default class OAuth2Client extends AuthClient {
         retry = false;
         // Force token refresh
         this.refreshAccessToken(() => {
-          // tslint:disable-next-line:no-use-before-declare
           this.getRequestMetadata(unusedUri, authCb);
         });
       } else {
@@ -346,7 +349,7 @@ export default class OAuth2Client extends AuthClient {
       }
     };
 
-    const authCb = (err, headers, response) => {
+    authCb = (err, headers, response) => {
       if (err) {
         postRequestCb(err, null, response);
       } else {

--- a/ts/lib/auth/refreshclient.ts
+++ b/ts/lib/auth/refreshclient.ts
@@ -15,7 +15,6 @@
  */
 
 import Auth2Client from './oauth2client';
-import * as util from 'util';
 
 export default class UserRefreshClient extends Auth2Client {
 

--- a/ts/test/test.oauth2.ts
+++ b/ts/test/test.oauth2.ts
@@ -21,7 +21,6 @@ import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as nock from 'nock';
 import * as path from 'path';
-import AuthClient from '../lib/auth/authclient';
 import GoogleAuth from '../lib/auth/googleauth';
 
 nock.disableNetConnect();

--- a/ts/test/test.transporters.ts
+++ b/ts/test/test.transporters.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import * as nock from 'nock';
-import { Transporter, DefaultTransporter } from '../lib/transporters';
+import { DefaultTransporter } from '../lib/transporters';
 
 // tslint:disable-next-line
 const version = require('../package.json').version;

--- a/tslint.json
+++ b/tslint.json
@@ -29,7 +29,8 @@
     "radix": true,
     "semicolon": [true, "always"],
     "switch-default": true,
-    "triple-equals": [true, "allow-null-check"]
+    "triple-equals": [true, "allow-null-check"],
 //    "variable-name": [true, "check-format", "ban-keywords"]
+    "variable-name": [true, "ban-keywords"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,37 +1,35 @@
 {
-  "lintOptions": {
-    "typeCheck": true
-  },
-  "extends": "tslint:latest",
   "rules": {
-    "ban": [true,
-      ["describe", "only"],
-      ["it", "only"],
-      ["Object", "assign"]
-    ],
-
-    "callable-types": true,
-    "interface-name": [false],
-    "interface-over-type-literal": true,
-    "file-header": [true,
-      "Copyright "
-    ],
-    "max-classes-per-file": [false],
-    "max-line-length": [true, 140],
-    "member-ordering": [false],
-    "no-angle-bracket-type-assertion": true,
-    "no-empty-interface": true,
-    "no-string-throw": true,
+    "class-name": true,
+    "comment-format": [true, "check-space"],
+    "eofline": true,
+    "forin": true,
+    "indent": [true, "spaces"],
+    "jsdoc-format": true,
+    "label-position": true,
+//    "label-undefined": true,
+    "no-arg": true,
+    "no-conditional-assignment": true,
+    "no-construct": true,
+    "no-debugger": true,
+//    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-inferrable-types": true,
+    "no-internal-module": true,
+    "no-shadowed-variable": true,
     "no-switch-case-fall-through": true,
-    "object-literal-sort-keys": false,
-    "object-literal-shorthand": false,
-    "ordered-imports": [
-      false
-    ],
-    "prefer-const": true,
-    "quotemark": [true, "single", "avoid-escape"],
-    "switch-default": false,
-    "trailing-comma": [false],
-    "variable-name": [false]
+    "no-trailing-whitespace": true,
+//    "no-unreachable": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "quotemark": [true, "single"],
+    "radix": true,
+    "semicolon": [true, "always"],
+    "switch-default": true,
+    "triple-equals": [true, "allow-null-check"]
+//    "variable-name": [true, "check-format", "ban-keywords"]
   }
 }


### PR DESCRIPTION
'variable-name' had to be disabled as this module has some public
members that don't follow the camelCase naming convention.

'no-duplicate-variable', 'no-unreachable' and 'label-undefined' are no
longer necessary as the compiler obviates these now.

This is dependent on #141.