### PR TITLE
use correct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/nock": "^8.2.1",
     "@types/node": "^7.0.13",
     "@types/request": "^0.0.42",
+    "clang-format": "^1.0.50",
     "coveralls": "^2.13.0",
     "del": "^2.2.2",
     "gulp": "^3.9.1",

--- a/ts/lib/auth/jwtclient.ts
+++ b/ts/lib/auth/jwtclient.ts
@@ -16,8 +16,10 @@
 
 import Auth2Client from './oauth2client';
 import * as gToken from 'gtoken';
+
 import JWTAccess from './jwtaccess';
-import { isString } from 'lodash';
+
+const isString = require('lodash.isstring');
 
 const noop = Function.prototype;
 

--- a/ts/lib/auth/oauth2client.ts
+++ b/ts/lib/auth/oauth2client.ts
@@ -17,8 +17,10 @@
 import AuthClient from './authclient';
 import LoginTicket from './loginticket';
 import PemVerifier from './../pemverifier';
-import { merge } from 'lodash';
 import * as querystring from 'querystring';
+
+const merge = require('lodash.merge');
+
 const noop = Function.prototype;
 
 export default class OAuth2Client extends AuthClient {


### PR DESCRIPTION
* we were using lodash in tests even though we don't depend on it.
* clang-format was missing from package.json