### PR TITLE
Treat 4xx and 5xx responses as errors

### DIFF
--- a/ts/lib/auth/oauth2client.ts
+++ b/ts/lib/auth/oauth2client.ts
@@ -297,7 +297,10 @@ export default class OAuth2Client extends AuthClient {
 
     return this.refreshToken(
         thisCreds.refresh_token, (err, tokens, response) => {
-          if (err) {
+          // If the error code is 403 or 404, fall-through to replace the error
+          // message. Otherwise, return the error.
+          if (err && (err as RequestError).code != 403 &&
+              (err as RequestError).code != 404) {
             return metadataCb(err, null, response);
           } else {
             if (!tokens || (tokens && !tokens.access_token)) {

--- a/ts/lib/auth/oauth2client.ts
+++ b/ts/lib/auth/oauth2client.ts
@@ -297,8 +297,8 @@ export default class OAuth2Client extends AuthClient {
 
     return this.refreshToken(
         thisCreds.refresh_token, (err, tokens, response) => {
-          // If the error code is 403 or 404, fall-through to replace the error
-          // message. Otherwise, return the error.
+          // If the error code is 403 or 404, go to the else so the error
+          // message is replaced. Otherwise, return the error.
           if (err && (err as RequestError).code != 403 &&
               (err as RequestError).code != 404) {
             return metadataCb(err, null, response);

--- a/ts/lib/transporters.ts
+++ b/ts/lib/transporters.ts
@@ -103,8 +103,8 @@ export class DefaultTransporter {
           (err as RequestError).code = body.error.code || res.statusCode;
         }
         body = null;
-      } else if (res.statusCode >= 500) {
-        // Consider all '500 responses' errors.
+      } else if (res.statusCode >= 400) {
+        // Consider all 4xx and 5xx responses errors.
         err = new RequestError(body);
         (err as RequestError).code = res.statusCode;
         body = null;

--- a/ts/test/test.transporters.ts
+++ b/ts/test/test.transporters.ts
@@ -71,4 +71,18 @@ describe('Transporters', () => {
           done();
         });
   });
+
+  it('should return an error for a 404 response', (done) => {
+    nock('http://example.com').get('/api').reply(404, 'Not found');
+
+    transporter.request(
+        {
+          uri: 'http://example.com/api',
+        },
+        (error) => {
+          assert(error.message === 'Not found');
+          assert.equal((error as RequestError).code, 404);
+          done();
+        });
+  });
 });


### PR DESCRIPTION
At the moment, 4xx and 5xx responses are returned in
google-api-nodejs-client as regular responses, not errors. From the user
perspective, this is an odd pattern.

This commit forces 4xx and 5xx responses to be returned as errors, and
not be treated as a successful requests.