### PR TITLE
refactor: keep CommonJS compat for module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/*
-lib/
-test/
+/lib/
+/test/
 types/
 .idea
 .vscode

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "engines": {
     "node": ">=0.10"
   },
-  "main": "./lib/auth/googleauth",
-  "types": "./types/lib/auth/googleauth.d.ts",
+  "main": "./lib/index.js",
+  "types": "./types/lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/google-auth-library-nodejs.git"

--- a/ts/lib/index.ts
+++ b/ts/lib/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import GoogleAuth from './auth/googleauth';
+
+// We re-export GoogleAuth as a CommonJS style module.exports to keep compat
+// with existing JS users of the library.
+export = GoogleAuth;

--- a/ts/test/test.index.ts
+++ b/ts/test/test.index.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+
+import GoogleAuth from '../lib/auth/googleauth';
+
+describe('module', () => {
+  it('should export GoogleAuth as a function', () => {
+    const cjs = require('../');
+    assert.strictEqual(typeof cjs, 'function');
+    assert.strictEqual(cjs, GoogleAuth);
+  });
+});


### PR DESCRIPTION
GoogleAuth is being exported as an ES6 class. This breaks compatibility
with existing JS users of this library for the main module export. This
change adds an index.js that re-exports GoogleAuth as a function.

Note that we are not using this hack for every single file in this
module. Anyone reaching into the internals of this module will need to
update their code.