### PR TITLE
feature: export DefaultTransport

### DIFF
--- a/ts/lib/auth/googleauth.ts
+++ b/ts/lib/auth/googleauth.ts
@@ -93,6 +93,11 @@ export class GoogleAuth {
   public UserRefreshClient = UserRefreshClient;
 
   /**
+   * Export DefaultTransporter as a static property of the class.
+   */
+  public static DefaultTransporter = DefaultTransporter;
+
+  /**
    * Obtains the default project ID for the application..
    * @param {function=} callback Optional callback.
    */

--- a/ts/test/test.index.ts
+++ b/ts/test/test.index.ts
@@ -16,11 +16,17 @@
 import * as assert from 'assert';
 
 import {GoogleAuth} from '../lib/auth/googleauth';
+import {DefaultTransporter} from '../lib/transporters';
 
 describe('module', () => {
   it('should export GoogleAuth as a function', () => {
     const cjs = require('../');
     assert.strictEqual(typeof cjs, 'function');
     assert.strictEqual(cjs, GoogleAuth);
+  });
+
+  it('should publicly export DefaultTransporter', () => {
+    const cjs = require('../');
+    assert.strictEqual(cjs.DefaultTransporter, DefaultTransporter);
   });
 });


### PR DESCRIPTION
Properly export DefaultTransport - some dependent libraries are using
this via loading an internal file.