### PR TITLE
BREAKING CHANGE: export class types and remove properties from GoogleAuth

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -85,38 +85,6 @@ export class GoogleAuth {
   cachedCredential: OAuth2Client|null = null;
 
   /**
-   * Convenience field mapping in the IAM credential type.
-   */
-  IAMAuth = IAMAuth;
-
-  /**
-   * Convenience field mapping in the Compute credential type.
-   */
-  Compute = Compute;
-
-  /**
-   * Convenience field mapping in the JWT credential type.
-   */
-  JWT = JWT;
-
-  /**
-   * Convenience field mapping in the JWT Access credential type.
-   */
-  JWTAccess = JWTAccess;
-
-  /**
-   * Convenience field mapping in the OAuth2 credential type.
-   */
-  // lint is checking for camelCase properties, but OAuth is proper here
-  // tslint:disable-next-line variable-name
-  OAuth2 = OAuth2Client;
-
-  /**
-   * Convenience field mapping to the UserRefreshClient credential type.
-   */
-  UserRefreshClient = UserRefreshClient;
-
-  /**
    * Export DefaultTransporter as a static property of the class.
    */
   static DefaultTransporter = DefaultTransporter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export {Compute} from './auth/computeclient';
 export {GoogleAuth} from './auth/googleauth';
+export {IAMAuth} from './auth/iam';
+export {JWTAccess} from './auth/jwtaccess';
+export {JWT} from './auth/jwtclient';
+export {OAuth2Client} from './auth/oauth2client';
+export {UserRefreshClient} from './auth/refreshclient';
 export {DefaultTransporter} from './transporters';

--- a/test/fixtures/kitchen/src/index.ts
+++ b/test/fixtures/kitchen/src/index.ts
@@ -1,8 +1,8 @@
-import {GoogleAuth} from 'google-auth-library';
+import {GoogleAuth, JWT} from 'google-auth-library';
 // uncomment the line below during development
 // import {GoogleAuth} from '../../../../build/src/index';
+const jwt = new JWT();
 const auth = new GoogleAuth();
-const jwt = new auth.JWT();
 async function getToken() {
   const token = await jwt.getToken('token');
   const projectId = await auth.getDefaultProjectId();

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -18,9 +18,9 @@ import * as assert from 'assert';
 import {AxiosRequestConfig} from 'axios';
 import * as nock from 'nock';
 
-import {Compute} from '../src/auth/computeclient';
 import {Credentials} from '../src/auth/credentials';
 import {GoogleAuth} from '../src/auth/googleauth';
+import {Compute} from '../src/index';
 
 nock.disableNetConnect();
 
@@ -28,8 +28,7 @@ describe('Initial credentials', () => {
   it('should create a dummy refresh token string', () => {
     // It is important that the compute client is created with a refresh token
     // value filled in, or else the rest of the logic will not work.
-    const auth = new GoogleAuth();
-    const compute = new auth.Compute();
+    const compute = new Compute();
     assert.equal('compute-placeholder', compute.credentials.refresh_token);
   });
 });
@@ -42,8 +41,7 @@ describe('Compute auth client', () => {
   // set up compute client.
   let compute: Compute;
   beforeEach(() => {
-    const auth = new GoogleAuth();
-    compute = new auth.Compute();
+    compute = new Compute();
   });
 
   it('should get an access token for the first request', done => {
@@ -86,8 +84,7 @@ describe('Compute auth client', () => {
 
   describe('.createScopedRequired', () => {
     it('should return false', () => {
-      const auth = new GoogleAuth();
-      const c = new auth.Compute();
+      const c = new Compute();
       assert.equal(false, c.createScopedRequired());
     });
   });

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -22,10 +22,8 @@ import * as nock from 'nock';
 import * as path from 'path';
 import * as stream from 'stream';
 
-import {GoogleAuth} from '../src/auth/googleauth';
-import {JWT} from '../src/auth/jwtclient';
-import {UserRefreshClient} from '../src/auth/refreshclient';
-import {BodyResponseCallback, DefaultTransporter} from '../src/transporters';
+import {DefaultTransporter, GoogleAuth, JWT, UserRefreshClient} from '../src/index';
+import {BodyResponseCallback} from '../src/transporters';
 
 nock.disableNetConnect();
 
@@ -327,8 +325,7 @@ describe('GoogleAuth', () => {
 
     describe('Refresh token', () => {
       it('should error on empty json', () => {
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT();
+        const jwt = new JWT();
         assert.throws(() => {
           jwt.fromJSON({});
         });
@@ -337,9 +334,7 @@ describe('GoogleAuth', () => {
       it('should error on missing client_id', () => {
         const json = createRefreshJSON();
         delete json.client_id;
-
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT();
+        const jwt = new JWT();
         assert.throws(() => {
           jwt.fromJSON(json);
         });
@@ -348,9 +343,7 @@ describe('GoogleAuth', () => {
       it('should error on missing client_secret', () => {
         const json = createRefreshJSON();
         delete json.client_secret;
-
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT();
+        const jwt = new JWT();
         assert.throws(() => {
           jwt.fromJSON(json);
         });
@@ -359,9 +352,7 @@ describe('GoogleAuth', () => {
       it('should error on missing refresh_token', () => {
         const json = createRefreshJSON();
         delete json.refresh_token;
-
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT();
+        const jwt = new JWT();
         assert.throws(() => {
           jwt.fromJSON(json);
         });

--- a/test/test.iam.ts
+++ b/test/test.iam.ts
@@ -15,16 +15,16 @@
  */
 
 import * as assert from 'assert';
-import {GoogleAuth} from '../src/auth/googleauth';
-import {IAMAuth, RequestMetadata} from '../src/auth/iam';
+
+import {RequestMetadata} from '../src/auth/iam';
+import {GoogleAuth, IAMAuth} from '../src/index';
 
 describe('.getRequestMetadata', () => {
   const testSelector = 'a-test-selector';
   const testToken = 'a-test-token';
   let client: IAMAuth;
   beforeEach(() => {
-    const auth = new GoogleAuth();
-    client = new auth.IAMAuth(testSelector, testToken);
+    client = new IAMAuth(testSelector, testToken);
   });
 
   it('passes the token and selector to the callback ', (done) => {

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -19,8 +19,7 @@ import * as fs from 'fs';
 import * as jws from 'jws';
 import * as nock from 'nock';
 import {JWTInput} from '../src/auth/credentials';
-import {GoogleAuth} from '../src/auth/googleauth';
-import {JWT} from '../src/auth/jwtclient';
+import {GoogleAuth, JWT} from '../src/index';
 
 const keypair = require('keypair');
 const noop = Function.prototype;
@@ -66,8 +65,7 @@ describe('Initial credentials', () => {
   it('should create a dummy refresh token string', () => {
     // It is important that the compute client is created with a refresh token
     // value filled in, or else the rest of the logic will not work.
-    const auth = new GoogleAuth();
-    const jwt = new auth.JWT();
+    const jwt = new JWT();
     assert.equal('jwt-placeholder', jwt.credentials.refresh_token);
   });
 });
@@ -75,8 +73,7 @@ describe('Initial credentials', () => {
 describe('JWT auth client', () => {
   describe('.authorize', () => {
     it('should get an initial access token', done => {
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', PEM_PATH, null,
           ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -100,8 +97,7 @@ describe('JWT auth client', () => {
     });
 
     it('should accept scope as string', done => {
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', '/path/to/key.pem', null, 'http://foo',
           'bar@subjectaccount.com');
 
@@ -116,8 +112,7 @@ describe('JWT auth client', () => {
   describe('.getAccessToken', () => {
     describe('when scopes are set', () => {
       it('can get obtain new access token', (done) => {
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT(
+        const jwt = new JWT(
             'foo@serviceaccount.com', PEM_PATH, null,
             ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -137,8 +132,7 @@ describe('JWT auth client', () => {
   describe('.getRequestMetadata', () => {
     describe('when scopes are set', () => {
       it('can obtain new access token', (done) => {
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT(
+        const jwt = new JWT(
             'foo@serviceaccount.com', PEM_PATH, null,
             ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -164,8 +158,7 @@ describe('JWT auth client', () => {
       it('gets a jwt header access token', (done) => {
         const keys = keypair(1024 /* bitsize of private key */);
         const email = 'foo@serviceaccount.com';
-        const auth = new GoogleAuth();
-        const jwt = new auth.JWT(
+        const jwt = new JWT(
             'foo@serviceaccount.com', null, keys.private, null,
             'ignored@subjectaccount.com');
 
@@ -191,8 +184,7 @@ describe('JWT auth client', () => {
 
   describe('.request', () => {
     it('should refresh token if missing access token', (done) => {
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', PEM_PATH, null,
           ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -206,8 +198,7 @@ describe('JWT auth client', () => {
     });
 
     it('should refresh token if expired', (done) => {
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', PEM_PATH, null,
           ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -226,9 +217,7 @@ describe('JWT auth client', () => {
 
     it('should refresh token if the server returns 403', (done) => {
       nock('http://example.com').get('/access').twice().reply(403);
-
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', PEM_PATH, null, ['http://example.com'],
           'bar@subjectaccount.com');
 
@@ -252,8 +241,7 @@ describe('JWT auth client', () => {
               .post('/o/oauth2/token', '*')
               .reply(200, {access_token: 'abc123', expires_in: 10000});
 
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', '/path/to/key.pem', null,
           ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -276,8 +264,7 @@ describe('JWT auth client', () => {
               .post('/o/oauth2/token', '*')
               .reply(200, {access_token: 'abc123', expires_in: 10000});
 
-      const auth = new GoogleAuth();
-      const jwt = new auth.JWT(
+      const jwt = new JWT(
           'foo@serviceaccount.com', '/path/to/key.pem', null,
           ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -295,8 +282,7 @@ describe('JWT auth client', () => {
   });
 
   it('should return expiry_date in milliseconds', async () => {
-    const auth = new GoogleAuth();
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', PEM_PATH, null, ['http://bar', 'http://foo'],
         'bar@subjectaccount.com');
 
@@ -313,14 +299,8 @@ describe('JWT auth client', () => {
 });
 
 describe('.createScoped', () => {
-  // set up the auth module.
-  let auth: GoogleAuth;
-  beforeEach(() => {
-    auth = new GoogleAuth();
-  });
-
   it('should clone stuff', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -333,7 +313,7 @@ describe('.createScoped', () => {
   });
 
   it('should handle string scope', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -342,7 +322,7 @@ describe('.createScoped', () => {
   });
 
   it('should handle array scope', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -354,7 +334,7 @@ describe('.createScoped', () => {
   });
 
   it('should handle null scope', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -363,7 +343,7 @@ describe('.createScoped', () => {
   });
 
   it('should set scope when scope was null', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null, null,
         'bar@subjectaccount.com');
 
@@ -372,7 +352,7 @@ describe('.createScoped', () => {
   });
 
   it('should handle nulls', () => {
-    const jwt = new auth.JWT();
+    const jwt = new JWT();
 
     const clone = jwt.createScoped('hi');
     assert.equal(jwt.email, null);
@@ -383,7 +363,7 @@ describe('.createScoped', () => {
   });
 
   it('should not return the original instance', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -393,14 +373,8 @@ describe('.createScoped', () => {
 });
 
 describe('.createScopedRequired', () => {
-  // set up the auth module.
-  let auth: GoogleAuth;
-  beforeEach(() => {
-    auth = new GoogleAuth();
-  });
-
   it('should return true when scopes is null', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null, null,
         'bar@subjectaccount.com');
 
@@ -408,7 +382,7 @@ describe('.createScopedRequired', () => {
   });
 
   it('should return true when scopes is an empty array', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null, [],
         'bar@subjectaccount.com');
 
@@ -416,7 +390,7 @@ describe('.createScopedRequired', () => {
   });
 
   it('should return true when scopes is an empty string', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null, '',
         'bar@subjectaccount.com');
 
@@ -424,7 +398,7 @@ describe('.createScopedRequired', () => {
   });
 
   it('should return false when scopes is a filled-in string', () => {
-    const jwt = new auth.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null, 'http://foo',
         'bar@subjectaccount.com');
 
@@ -432,8 +406,7 @@ describe('.createScopedRequired', () => {
   });
 
   it('should return false when scopes is a filled-in array', () => {
-    const auth2 = new GoogleAuth();
-    const jwt = new auth2.JWT(
+    const jwt = new JWT(
         'foo@serviceaccount.com', '/path/to/key.pem', null,
         ['http://bar', 'http://foo'], 'bar@subjectaccount.com');
 
@@ -442,8 +415,7 @@ describe('.createScopedRequired', () => {
 
   it('should return false when scopes is not an array or a string, but can be used as a string',
      () => {
-       const auth2 = new GoogleAuth();
-       const jwt = new auth2.JWT(
+       const jwt = new JWT(
            'foo@serviceaccount.com', '/path/to/key.pem', null, '2',
            'bar@subjectaccount.com');
 
@@ -457,8 +429,7 @@ describe('.fromJson', () => {
   let json: JWTInput;
   beforeEach(() => {
     json = createJSON();
-    const auth = new GoogleAuth();
-    jwt = new auth.JWT();
+    jwt = new JWT();
   });
 
   it('should error on null json', () => {
@@ -519,8 +490,7 @@ describe('.fromStream', () => {
   // set up the jwt instance being tested.
   let jwt: JWT;
   beforeEach(() => {
-    const auth = new GoogleAuth();
-    jwt = new auth.JWT();
+    jwt = new JWT();
   });
 
   it('should error on null stream', (done) => {
@@ -561,8 +531,7 @@ describe('.fromAPIKey', () => {
   let jwt: JWT;
   const KEY = 'test';
   beforeEach(() => {
-    const auth = new GoogleAuth();
-    jwt = new auth.JWT();
+    jwt = new JWT();
   });
   describe('exception behaviour', () => {
     it('should error without api key', () => {

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -20,8 +20,7 @@ import * as http from 'http';
 import * as jws from 'jws';
 
 import {JWTInput} from '../src/auth/credentials';
-import {GoogleAuth} from '../src/auth/googleauth';
-import {JWTAccess} from '../src/auth/jwtaccess';
+import {GoogleAuth, JWTAccess} from '../src/index';
 
 const keypair = require('keypair');
 
@@ -41,8 +40,7 @@ describe('.getRequestMetadata', () => {
     const keys = keypair(1024 /* bitsize of private key */);
     const testUri = 'http:/example.com/my_test_service';
     const email = 'foo@serviceaccount.com';
-    const auth = new GoogleAuth();
-    const client = new auth.JWTAccess(email, keys.private);
+    const client = new JWTAccess(email, keys.private);
     const res = client.getRequestMetadata(testUri);
     assert.notStrictEqual(
         null, res.headers, 'an creds object should be present');
@@ -57,8 +55,7 @@ describe('.getRequestMetadata', () => {
 
 describe('.createScopedRequired', () => {
   it('should return false', () => {
-    const auth = new GoogleAuth();
-    const client = new auth.JWTAccess('foo@serviceaccount.com', null);
+    const client = new JWTAccess('foo@serviceaccount.com', null);
     assert.equal(false, client.createScopedRequired());
   });
 });
@@ -69,8 +66,7 @@ describe('.fromJson', () => {
   let client: JWTAccess;
   beforeEach(() => {
     json = createJSON();
-    const auth = new GoogleAuth();
-    client = new auth.JWTAccess();
+    client = new JWTAccess();
   });
 
   it('should error on null json', () => {
@@ -116,8 +112,7 @@ describe('.fromStream', () => {
   // set up the client instance being tested.
   let client: JWTAccess;
   beforeEach(() => {
-    const auth = new GoogleAuth();
-    client = new auth.JWTAccess();
+    client = new JWTAccess();
   });
 
   it('should error on null stream', (done) => {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -23,7 +23,7 @@ import * as path from 'path';
 import * as qs from 'querystring';
 import * as url from 'url';
 
-import {GoogleAuth} from '../src/auth/googleauth';
+import {GoogleAuth, OAuth2Client} from '../src/index';
 
 nock.disableNetConnect();
 
@@ -44,7 +44,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated = oauth2client.generateAuthUrl(opts);
     const parsed = url.parse(generated);
     const query = qs.parse(parsed.query);
@@ -66,7 +66,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated = oauth2client.generateAuthUrl(opts);
     const parsed = url.parse(generated);
     const query = qs.parse(parsed.query);
@@ -80,7 +80,7 @@ describe('OAuth2 client', () => {
      (done) => {
        const auth = new GoogleAuth();
        const oauth2client =
-           new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
        const generated = oauth2client.generateAuthUrl();
        const parsed = url.parse(generated);
        const query = qs.parse(parsed.query);
@@ -101,7 +101,7 @@ describe('OAuth2 client', () => {
   });
 
   it('should not throw any exceptions if only refresh token is set', () => {
-    const oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET,
+    const oauth2client = new googleapis.OAuth2Client(CLIENT_ID, CLIENT_SECRET,
   REDIRECT_URI); oauth2client.credentials = { refresh_token: 'refresh_token' };
     assert.doesNotThrow(() => {
       const google = new googleapis.GoogleApis();
@@ -111,7 +111,7 @@ describe('OAuth2 client', () => {
   });
 
   it('should set access token type to Bearer if none is set', (done) => {
-    const oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET,
+    const oauth2client = new googleapis.OAuth2Client(CLIENT_ID, CLIENT_SECRET,
   REDIRECT_URI); oauth2client.credentials = { access_token: 'foo',
   refresh_token: '' };
 
@@ -162,7 +162,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const login = oauth2client.verifySignedJwtWithCerts(
         data, {keyid: publicKey}, 'testaudience');
 
@@ -204,7 +204,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -247,7 +247,7 @@ describe('OAuth2 client', () => {
     const validAudiences = ['testaudience', 'extra-audience'];
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, validAudiences);
@@ -287,7 +287,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -330,7 +330,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -373,7 +373,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -410,7 +410,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -450,7 +450,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -492,7 +492,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -536,7 +536,7 @@ describe('OAuth2 client', () => {
 
        const auth = new GoogleAuth();
        const oauth2client =
-           new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
        assert.throws(() => {
          oauth2client.verifySignedJwtWithCerts(
              data, {keyid: publicKey}, 'testaudience');
@@ -581,7 +581,7 @@ describe('OAuth2 client', () => {
 
        const auth = new GoogleAuth();
        const oauth2client =
-           new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
        oauth2client.verifySignedJwtWithCerts(
            data, {keyid: publicKey}, 'testaudience', ['testissuer'], maxExpiry);
 
@@ -623,7 +623,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -667,7 +667,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience');
@@ -709,7 +709,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     assert.throws(() => {
       oauth2client.verifySignedJwtWithCerts(
           data, {keyid: publicKey}, 'testaudience', ['testissuer']);
@@ -751,7 +751,7 @@ describe('OAuth2 client', () => {
 
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.verifySignedJwtWithCerts(
         data, {keyid: publicKey}, 'testaudience', ['testissuer']);
 
@@ -767,7 +767,7 @@ describe('OAuth2 client', () => {
                 path.join(__dirname, '../../test/fixtures/oauthcerts.json'));
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.getFederatedSignonCerts((err, certs) => {
       assert.equal(err, null);
       assert.equal(Object.keys(certs).length, 2);
@@ -794,7 +794,7 @@ describe('OAuth2 client', () => {
                    path.join(__dirname, '../../test/fixtures/oauthcerts.json'));
        const auth = new GoogleAuth();
        const oauth2client =
-           new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
        oauth2client.getFederatedSignonCerts((err, certs) => {
          assert.equal(err, null);
          assert.equal(Object.keys(certs).length, 2);
@@ -811,7 +811,7 @@ describe('OAuth2 client', () => {
   it('should set redirect_uri if not provided in options', () => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated = oauth2client.generateAuthUrl({});
     const parsed = url.parse(generated);
     const query = qs.parse(parsed.query);
@@ -821,7 +821,7 @@ describe('OAuth2 client', () => {
   it('should set client_id if not provided in options', () => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated = oauth2client.generateAuthUrl({});
     const parsed = url.parse(generated);
     const query = qs.parse(parsed.query);
@@ -831,7 +831,7 @@ describe('OAuth2 client', () => {
   it('should override redirect_uri if provided in options', () => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated =
         oauth2client.generateAuthUrl({redirect_uri: 'overridden'});
     const parsed = url.parse(generated);
@@ -842,7 +842,7 @@ describe('OAuth2 client', () => {
   it('should override client_id if provided in options', () => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     const generated =
         oauth2client.generateAuthUrl({client_id: 'client_override'});
     const parsed = url.parse(generated);
@@ -853,7 +853,7 @@ describe('OAuth2 client', () => {
   it('should return error in callback on request', (done) => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.request({}, (err, result) => {
       assert.equal(err!.message, 'No access, refresh token or API key is set.');
       assert.equal(result, null);
@@ -864,7 +864,7 @@ describe('OAuth2 client', () => {
   it('should return error in callback on refreshAccessToken', (done) => {
     const auth = new GoogleAuth();
     const oauth2client =
-        new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     oauth2client.refreshAccessToken((err, result) => {
       assert.equal(err!.message, 'No refresh token is set.');
       assert.equal(result, null);
@@ -890,7 +890,7 @@ describe('OAuth2 client', () => {
     it('should refresh token if missing access token', (done) => {
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 
       oauth2client.credentials = {refresh_token: 'refresh-token-placeholder'};
 
@@ -903,7 +903,7 @@ describe('OAuth2 client', () => {
     it('should refresh if access token is expired', (done) => {
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 
       oauth2client.setCredentials({
         access_token: 'initial-access-token',
@@ -920,7 +920,7 @@ describe('OAuth2 client', () => {
     it('should not refresh if not expired', (done) => {
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 
       oauth2client.credentials = {
         access_token: 'initial-access-token',
@@ -939,7 +939,7 @@ describe('OAuth2 client', () => {
     it('should assume access token is not expired', (done) => {
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 
       oauth2client.credentials = {
         access_token: 'initial-access-token',
@@ -962,7 +962,7 @@ describe('OAuth2 client', () => {
 
         const auth = new GoogleAuth();
         const oauth2client =
-            new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+            new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 
         oauth2client.credentials = {
           access_token: 'initial-access-token',
@@ -984,7 +984,7 @@ describe('OAuth2 client', () => {
                         .reply(200, {success: true});
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.credentials = {access_token: 'abc', refresh_token: 'abc'};
       oauth2client.revokeCredentials((err, result) => {
         assert.equal(err, null);
@@ -999,7 +999,7 @@ describe('OAuth2 client', () => {
        (done) => {
          const auth = new GoogleAuth();
          const oauth2client =
-             new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+             new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
          oauth2client.credentials = {refresh_token: 'abc'};
          oauth2client.revokeCredentials((err, result) => {
            assert.equal(err!.message, 'No access token to revoke.');
@@ -1021,7 +1021,7 @@ describe('OAuth2 client', () => {
                   {access_token: 'abc', refresh_token: '123', expires_in: 10});
       const auth = new GoogleAuth();
       const oauth2client =
-          new auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.getToken('code here', (err, tokens) => {
         assert(tokens!.expiry_date! >= now + (10 * 1000));
         assert(tokens!.expiry_date! <= now + (15 * 1000));

--- a/test/test.refresh.ts
+++ b/test/test.refresh.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as nock from 'nock';
 
-import {GoogleAuth} from '../src/auth/googleauth';
+import {GoogleAuth, UserRefreshClient} from '../src/index';
 
 nock.disableNetConnect();
 
@@ -34,8 +34,7 @@ function createJSON() {
 
 describe('.fromJson', () => {
   it('should error on null json', () => {
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     assert.throws(() => {
       // Test verifies invalid parameter tests, which requires cast to any.
       // tslint:disable-next-line no-any
@@ -44,8 +43,7 @@ describe('.fromJson', () => {
   });
 
   it('should error on empty json', () => {
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     assert.throws(() => {
       // Test verifies invalid parameter tests, which requires cast to any.
       // tslint:disable-next-line no-any
@@ -56,8 +54,7 @@ describe('.fromJson', () => {
   it('should error on missing client_id', () => {
     const json = createJSON();
     delete json.client_id;
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     assert.throws(() => {
       refresh.fromJSON(json);
     });
@@ -66,8 +63,7 @@ describe('.fromJson', () => {
   it('should error on missing client_secret', () => {
     const json = createJSON();
     delete json.client_secret;
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     assert.throws(() => {
       refresh.fromJSON(json);
     });
@@ -76,8 +72,7 @@ describe('.fromJson', () => {
   it('should error on missing refresh_token', () => {
     const json = createJSON();
     delete json.refresh_token;
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     assert.throws(() => {
       refresh.fromJSON(json);
     });
@@ -85,24 +80,21 @@ describe('.fromJson', () => {
 
   it('should create UserRefreshClient with clientId_', () => {
     const json = createJSON();
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     const result = refresh.fromJSON(json);
     assert.equal(json.client_id, refresh._clientId);
   });
 
   it('should create UserRefreshClient with clientSecret_', () => {
     const json = createJSON();
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     const result = refresh.fromJSON(json);
     assert.equal(json.client_secret, refresh._clientSecret);
   });
 
   it('should create UserRefreshClient with _refreshToken', () => {
     const json = createJSON();
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     const result = refresh.fromJSON(json);
     assert.equal(json.refresh_token, refresh._refreshToken);
   });
@@ -110,8 +102,7 @@ describe('.fromJson', () => {
 
 describe('.fromStream', () => {
   it('should error on null stream', (done) => {
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     // Test verifies invalid parameter tests, which requires cast to any.
     // tslint:disable-next-line no-any
     (refresh as any).fromStream(null, (err: Error) => {
@@ -130,8 +121,7 @@ describe('.fromStream', () => {
     const stream = fs.createReadStream('./test/fixtures/refresh.json');
 
     // And pass it into the fromStream method.
-    const auth = new GoogleAuth();
-    const refresh = new auth.UserRefreshClient();
+    const refresh = new UserRefreshClient();
     refresh.fromStream(stream, (err) => {
       assert.ifError(err);
 


### PR DESCRIPTION
When writing samples, I noticed that today I need to instantiate a new `GoogleAuth`, then from that instance you get access to the types needed to create new `JWT`, `UserRefreshClient`, and `OAuth2Client` objects.  That's silly.  Instead, I just added them to the exports on the index.  