### PR TITLE
docs: document proxy behavior and verify with a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ main();
 The parameters for the JWT auth client including how to use it with a `.pem` file are explained in [samples/jwt.js](samples/jwt.js).
 
 #### Loading credentials from environment variables
-
 Instead of loading credentials from a key file, you can also provide them using an environment variable and the `GoogleAuth.fromJSON()` method.  This is particularly convenient for systems that deploy directly from source control (Heroku, App Engine, etc).
 
 Start by exporting your credentials:
@@ -290,6 +289,13 @@ async function main() {
 
 main().catch(console.error);
 ```
+#### Using a Proxy
+You can use the following environment variables to proxy HTTP and HTTPS requests:
+
+- HTTP_PROXY / http_proxy
+- HTTPS_PROXY / https_proxy
+
+When HTTP_PROXY / http_proxy are set, they will be used to proxy non-SSL requests that do not have an explicit proxy configuration option present. Similarly, HTTPS_PROXY / https_proxy will be respected for SSL requests that do not have an explicit proxy configuration option. It is valid to define a proxy in one of the environment variables, but then override it for a specific request, using the proxy configuration option.
 
 ### Questions/problems?
 

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -98,6 +98,19 @@ describe('Transporters', () => {
           done();
         });
   });
+});
+
+describe('transporter proxy', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = process.env;
+    process.env = {};
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
 
   it('should use the http proxy if one is configured', async () => {
     process.env['http_proxy'] = 'http://han:solo@proxy-server:1234';
@@ -115,7 +128,6 @@ describe('Transporters', () => {
     const url = 'http://example.com/fake';
     const result = await transporter.request({url});
     assert.equal(result.status, 200);
-    process.env['http_proxy'] = undefined;
   });
 
   it('should use the https proxy if one is configured', async () => {
@@ -134,6 +146,5 @@ describe('Transporters', () => {
     const url = 'https://example.com/fake';
     const result = await transporter.request({url});
     assert.equal(result.status, 200);
-    process.env['https_proxy'] = undefined;
   });
 });

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import {AxiosRequestConfig} from 'axios';
+import {AxiosProxyConfig, AxiosRequestConfig} from 'axios';
 import * as nock from 'nock';
 
 import {DefaultTransporter, RequestError} from '../src/transporters';
@@ -97,5 +97,43 @@ describe('Transporters', () => {
           assert.equal(error!.message, expected);
           done();
         });
+  });
+
+  it('should use the http proxy if one is configured', async () => {
+    process.env['http_proxy'] = 'http://han:solo@proxy-server:1234';
+    const transporter = new DefaultTransporter();
+    nock('http://proxy-server:1234')
+        .get('http://example.com/fake', undefined, {
+          reqheaders: {
+            'host': 'example.com',
+            'accept': /.*/g,
+            'user-agent': /google-api-nodejs-client\/.*/g,
+            'proxy-authorization': /.*/g
+          }
+        })
+        .reply(200);
+    const url = 'http://example.com/fake';
+    const result = await transporter.request({url});
+    assert.equal(result.status, 200);
+    process.env['http_proxy'] = undefined;
+  });
+
+  it('should use the https proxy if one is configured', async () => {
+    process.env['https_proxy'] = 'https://han:solo@proxy-server:1234';
+    const transporter = new DefaultTransporter();
+    nock('https://proxy-server:1234')
+        .get('https://example.com/fake', undefined, {
+          reqheaders: {
+            'host': 'example.com',
+            'accept': /.*/g,
+            'user-agent': /google-api-nodejs-client\/.*/g,
+            'proxy-authorization': /.*/g
+          }
+        })
+        .reply(200);
+    const url = 'https://example.com/fake';
+    const result = await transporter.request({url});
+    assert.equal(result.status, 200);
+    process.env['https_proxy'] = undefined;
   });
 });


### PR DESCRIPTION
The axios npm module supports setting an HTTP or HTTPS proxy via the http_proxy and https_proxy environment variables.  It also happens to be undocumented, which I didn't figure out until writing my own implementation  😂

Here I'm just adding a few tests, and updating our docs.  I will follow up with a PR against the axios docs to save others from my fate.  

Addresses #65. 