### PR TITLE
fix: pin follow-redirects to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "axios": "^0.17.1",
     "gtoken": "^2.0.2",
     "jws": "^3.1.4",
-    "lodash.isstring": "^4.0.1"
+    "lodash.isstring": "^4.0.1",
+    "follow-redirects": "1.2.6"
   },
   "devDependencies": {
     "@types/jws": "^3.1.0",


### PR DESCRIPTION
While working on a very simple change, CI started to fail:
https://travis-ci.org/google/google-auth-library-nodejs/builds/325898451?utm_source=github_status&utm_medium=notification

After some digging, it was due to an update of the follow-redirects npm module, which is used in axios.  One of the commits in the 1.3 release broke interaction with nock in specific cases, which is causing tests to fail.  This only affects node.js 4 and 6, which don't support lock files.

To solve the root issue, I've opened these bugs:
- https://github.com/olalonde/follow-redirects/issues/77
- https://github.com/axios/axios/issues/1271

To protect us in the short term, I want to pin to a specific version of the follow-redirects npm module that's known to work.  In the meantime, I'll work across the nock, axios, and follow-redirects module authors to figure out what's happening.  