### PR TITLE
feat: Add ability to refresh token automatically before expiration.

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -33,8 +33,8 @@ export class Compute extends OAuth2Client {
    * Retrieve access token from the metadata server.
    * See: https://developers.google.com/compute/docs/authentication
    */
-  constructor() {
-    super();
+  constructor(refreshTokenEarlyMillis?: number) {
+    super({refreshTokenEarlyMillis});
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.
     this.credentials = {expiry_date: 1, refresh_token: 'compute-placeholder'};

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -20,6 +20,8 @@ import {RequestError} from './../transporters';
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
+export interface ComputeOptions extends RefreshOptions {}
+
 export class Compute extends OAuth2Client {
   /**
    * Google Compute Engine metadata server token endpoint.
@@ -33,7 +35,7 @@ export class Compute extends OAuth2Client {
    * Retrieve access token from the metadata server.
    * See: https://developers.google.com/compute/docs/authentication
    */
-  constructor(options?: RefreshOptions) {
+  constructor(options?: ComputeOptions) {
     super(options);
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -37,7 +37,7 @@ export class Compute extends OAuth2Client {
    */
   constructor(options?: ComputeOptions) {
     options = options || {};
-    super({refreshTokenEarlyMillis: options.refreshTokenEarlyMillis});
+    super({eagerRefreshThresholdMillis: options.eagerRefreshThresholdMillis});
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.
     this.credentials = {expiry_date: 1, refresh_token: 'compute-placeholder'};

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -20,8 +20,6 @@ import {RequestError} from './../transporters';
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
-export interface ComputeOptions extends RefreshOptions {}
-
 export class Compute extends OAuth2Client {
   /**
    * Google Compute Engine metadata server token endpoint.
@@ -35,9 +33,8 @@ export class Compute extends OAuth2Client {
    * Retrieve access token from the metadata server.
    * See: https://developers.google.com/compute/docs/authentication
    */
-  constructor(options?: ComputeOptions) {
-    options = options || {};
-    super({eagerRefreshThresholdMillis: options.eagerRefreshThresholdMillis});
+  constructor(options?: RefreshOptions) {
+    super(options);
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.
     this.credentials = {expiry_date: 1, refresh_token: 'compute-placeholder'};

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -20,6 +20,8 @@ import {RequestError} from './../transporters';
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client} from './oauth2client';
 
+export interface ComputeOptions { refreshTokenEarlyMillis?: number; }
+
 export class Compute extends OAuth2Client {
   /**
    * Google Compute Engine metadata server token endpoint.
@@ -33,8 +35,9 @@ export class Compute extends OAuth2Client {
    * Retrieve access token from the metadata server.
    * See: https://developers.google.com/compute/docs/authentication
    */
-  constructor(refreshTokenEarlyMillis?: number) {
-    super({refreshTokenEarlyMillis});
+  constructor(options?: ComputeOptions) {
+    options = options || {};
+    super({refreshTokenEarlyMillis: options.refreshTokenEarlyMillis});
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.
     this.credentials = {expiry_date: 1, refresh_token: 'compute-placeholder'};

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -18,9 +18,9 @@ import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios
 
 import {RequestError} from './../transporters';
 import {CredentialRequest, Credentials} from './credentials';
-import {GetTokenResponse, OAuth2Client} from './oauth2client';
+import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
-export interface ComputeOptions { refreshTokenEarlyMillis?: number; }
+export interface ComputeOptions extends RefreshOptions {}
 
 export class Compute extends OAuth2Client {
   /**

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -58,8 +58,6 @@ interface CredentialResult {
   default: {email: string;};
 }
 
-export interface GoogleAuthOptions extends RefreshOptions {}
-
 export class GoogleAuth {
   transporter: Transporter;
 
@@ -90,11 +88,6 @@ export class GoogleAuth {
    * Export DefaultTransporter as a static property of the class.
    */
   static DefaultTransporter = DefaultTransporter;
-
-  constructor(options?: GoogleAuthOptions) {
-    options = options || {};
-    this.eagerRefreshThresholdMillis= options.eagerRefreshThresholdMillis;
-  }
 
   /**
    * Obtains the default project ID for the application..
@@ -236,6 +229,14 @@ export class GoogleAuth {
           'Unexpected error while acquiring application default credentials: ' +
           e.message);
     }
+  }
+
+  /**
+   * Sets time to eagerly refresh tokens before they are expired.
+   * @param {number=} eagerRefreshThresholdMillis Time in ms to refresh an unexpired token before it expires.
+   */
+  setEagerRefreshThresholdMillis(eagerRefreshThresholdMillis: number) {
+    this.eagerRefreshThresholdMillis = eagerRefreshThresholdMillis;
   }
 
   /**
@@ -388,7 +389,8 @@ export class GoogleAuth {
       client = new UserRefreshClient(
           {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     } else {
-      client = new JWT({eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
+      client = new JWT(
+          {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     }
     client.fromJSON(json);
     return client;
@@ -442,8 +444,8 @@ export class GoogleAuth {
    * @returns A JWT loaded from the key
    */
   fromAPIKey(apiKey: string): JWT {
-    const client =
-        new JWT({eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
+    const client = new JWT(
+        {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     client.fromAPIKey(apiKey);
     return client;
   }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -219,7 +219,8 @@ export class GoogleAuth {
         // TODO: cache the result
         return {
           projectId: null,
-          credential: new Compute(this.refreshTokenEarlyMillis)
+          credential: new Compute(
+              {refreshTokenEarlyMillis: this.refreshTokenEarlyMillis})
         };
       } else {
         // We failed to find the default credentials. Bail out with an error.
@@ -381,7 +382,7 @@ export class GoogleAuth {
     this.jsonContent = json;
     if (json.type === 'authorized_user') {
       client = new UserRefreshClient(
-          undefined, undefined, undefined, this.refreshTokenEarlyMillis);
+          {refreshTokenEarlyMillis: this.refreshTokenEarlyMillis});
     } else {
       client = new JWT({refreshTokenEarlyMillis: this.refreshTokenEarlyMillis});
     }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -82,8 +82,6 @@ export class GoogleAuth {
 
   cachedCredential: OAuth2Client|null = null;
 
-  private eagerRefreshThresholdMillis: number|undefined;
-
   /**
    * Export DefaultTransporter as a static property of the class.
    */
@@ -167,17 +165,28 @@ export class GoogleAuth {
    */
   getApplicationDefault(): Promise<ADCResponse>;
   getApplicationDefault(callback: ADCCallback): void;
-  getApplicationDefault(callback?: ADCCallback): void|Promise<ADCResponse> {
+  getApplicationDefault(options: RefreshOptions): Promise<ADCResponse>;
+  getApplicationDefault(options: RefreshOptions, callback: ADCCallback): void;
+  getApplicationDefault(
+      optionsOrCallback: ADCCallback|RefreshOptions = {},
+      callback?: ADCCallback): void|Promise<ADCResponse> {
+    let options: RefreshOptions|undefined;
+    if (typeof optionsOrCallback === 'function') {
+      callback = optionsOrCallback;
+    } else {
+      options = optionsOrCallback;
+    }
     if (callback) {
-      this.getApplicationDefaultAsync()
-          .then(r => callback(null, r.credential, r.projectId))
+      this.getApplicationDefaultAsync(options)
+          .then(r => callback!(null, r.credential, r.projectId))
           .catch(callback);
     } else {
-      return this.getApplicationDefaultAsync();
+      return this.getApplicationDefaultAsync(options);
     }
   }
 
-  private async getApplicationDefaultAsync(): Promise<ADCResponse> {
+  private async getApplicationDefaultAsync(options?: RefreshOptions):
+      Promise<ADCResponse> {
     // If we've already got a cached credential, just return it.
     if (this.cachedCredential) {
       return {
@@ -192,7 +201,8 @@ export class GoogleAuth {
     // location of the credential file. This is typically used in local
     // developer scenarios.
     credential =
-        await this._tryGetApplicationCredentialsFromEnvironmentVariable();
+        await this._tryGetApplicationCredentialsFromEnvironmentVariable(
+            options);
     if (credential) {
       this.cachedCredential = credential;
       projectId = await this.getDefaultProjectId();
@@ -200,7 +210,8 @@ export class GoogleAuth {
     }
 
     // Look in the well-known credential file location.
-    credential = await this._tryGetApplicationCredentialsFromWellKnownFile();
+    credential =
+        await this._tryGetApplicationCredentialsFromWellKnownFile(options);
     if (credential) {
       this.cachedCredential = credential;
       projectId = await this.getDefaultProjectId();
@@ -214,11 +225,7 @@ export class GoogleAuth {
         // For GCE, just return a default ComputeClient. It will take care of
         // the rest.
         // TODO: cache the result
-        return {
-          projectId: null,
-          credential: new Compute(
-              {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis})
-        };
+        return {projectId: null, credential: new Compute(options)};
       } else {
         // We failed to find the default credentials. Bail out with an error.
         throw new Error(
@@ -229,14 +236,6 @@ export class GoogleAuth {
           'Unexpected error while acquiring application default credentials: ' +
           e.message);
     }
-  }
-
-  /**
-   * Sets time to eagerly refresh tokens before they are expired.
-   * @param {number=} eagerRefreshThresholdMillis Time in ms to refresh an unexpired token before it expires.
-   */
-  setEagerRefreshThresholdMillis(eagerRefreshThresholdMillis: number) {
-    this.eagerRefreshThresholdMillis = eagerRefreshThresholdMillis;
   }
 
   /**
@@ -280,14 +279,15 @@ export class GoogleAuth {
    * @returns Promise that resolves with the OAuth2Client or null.
    * @api private
    */
-  async _tryGetApplicationCredentialsFromEnvironmentVariable():
-      Promise<JWT|UserRefreshClient|null> {
+  async _tryGetApplicationCredentialsFromEnvironmentVariable(
+      options?: RefreshOptions): Promise<JWT|UserRefreshClient|null> {
     const credentialsPath = this._getEnv('GOOGLE_APPLICATION_CREDENTIALS');
     if (!credentialsPath || credentialsPath.length === 0) {
       return null;
     }
     try {
-      return this._getApplicationCredentialsFromFilePath(credentialsPath);
+      return this._getApplicationCredentialsFromFilePath(
+          credentialsPath, options);
     } catch (e) {
       throw this.createError(
           'Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.',
@@ -300,8 +300,8 @@ export class GoogleAuth {
    * @return Promise that resolves with the OAuth2Client or null.
    * @api private
    */
-  async _tryGetApplicationCredentialsFromWellKnownFile():
-      Promise<JWT|UserRefreshClient|null> {
+  async _tryGetApplicationCredentialsFromWellKnownFile(
+      options?: RefreshOptions): Promise<JWT|UserRefreshClient|null> {
     // First, figure out the location of the file, depending upon the OS type.
     let location = null;
     if (this._isWindows()) {
@@ -330,7 +330,7 @@ export class GoogleAuth {
       return null;
     }
     // The file seems to exist. Try to use it.
-    return this._getApplicationCredentialsFromFilePath(location);
+    return this._getApplicationCredentialsFromFilePath(location, options);
   }
 
   /**
@@ -339,8 +339,9 @@ export class GoogleAuth {
    * @returns Promise that resolves with the OAuth2Client
    * @api private
    */
-  async _getApplicationCredentialsFromFilePath(filePath: string):
-      Promise<JWT|UserRefreshClient> {
+  async _getApplicationCredentialsFromFilePath(
+      filePath: string,
+      options: RefreshOptions = {}): Promise<JWT|UserRefreshClient> {
     // Make sure the path looks like a string.
     if (!filePath || filePath.length === 0) {
       throw new Error('The file path is invalid.');
@@ -366,7 +367,7 @@ export class GoogleAuth {
     // Now open a read stream on the file, and parse it.
     try {
       const readStream = this._createReadStream(filePath);
-      return this.fromStream(readStream);
+      return this.fromStream(readStream, options);
     } catch (err) {
       throw this.createError(
           util.format('Unable to read the file at %s.', filePath), err);
@@ -378,19 +379,18 @@ export class GoogleAuth {
    * @param {object=} json The input object.
    * @returns JWT or UserRefresh Client with data
    */
-  fromJSON(json: JWTInput): JWT|UserRefreshClient {
+  fromJSON(json: JWTInput, options?: RefreshOptions): JWT|UserRefreshClient {
     let client: UserRefreshClient|JWT;
     if (!json) {
       throw new Error(
           'Must pass in a JSON object containing the Google auth settings.');
     }
     this.jsonContent = json;
+    options = options || {};
     if (json.type === 'authorized_user') {
-      client = new UserRefreshClient(
-          {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
+      client = new UserRefreshClient(options);
     } else {
-      client = new JWT(
-          {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
+      client = new JWT(options);
     }
     client.fromJSON(json);
     return client;
@@ -403,19 +403,33 @@ export class GoogleAuth {
    */
   fromStream(inputStream: stream.Readable): Promise<JWT|UserRefreshClient>;
   fromStream(inputStream: stream.Readable, callback: CredentialCallback): void;
-  fromStream(inputStream: stream.Readable, callback?: CredentialCallback):
-      Promise<JWT|UserRefreshClient>|void {
+  fromStream(inputStream: stream.Readable, options: RefreshOptions):
+      Promise<JWT|UserRefreshClient>;
+  fromStream(
+      inputStream: stream.Readable, options: RefreshOptions,
+      callback: CredentialCallback): void;
+  fromStream(
+      inputStream: stream.Readable,
+      optionsOrCallback: RefreshOptions|CredentialCallback = {},
+      callback?: CredentialCallback): Promise<JWT|UserRefreshClient>|void {
+    let options: RefreshOptions = {};
+    if (typeof optionsOrCallback === 'function') {
+      callback = optionsOrCallback;
+    } else {
+      options = optionsOrCallback;
+    }
     if (callback) {
-      this.fromStreamAsync(inputStream)
-          .then(r => callback(null, r))
+      this.fromStreamAsync(inputStream, options)
+          .then(r => callback!(null, r))
           .catch(callback);
     } else {
-      return this.fromStreamAsync(inputStream);
+      return this.fromStreamAsync(inputStream, options);
     }
   }
 
-  private fromStreamAsync(inputStream: stream.Readable):
-      Promise<JWT|UserRefreshClient> {
+  private fromStreamAsync(
+      inputStream: stream.Readable,
+      options?: RefreshOptions): Promise<JWT|UserRefreshClient> {
     return new Promise((resolve, reject) => {
       if (!inputStream) {
         throw new Error(
@@ -429,7 +443,7 @@ export class GoogleAuth {
       inputStream.on('end', () => {
         try {
           const data = JSON.parse(s);
-          const r = this.fromJSON(data);
+          const r = this.fromJSON(data, options);
           return resolve(r);
         } catch (err) {
           return reject(err);
@@ -443,9 +457,9 @@ export class GoogleAuth {
    * @param {string} - The API key string
    * @returns A JWT loaded from the key
    */
-  fromAPIKey(apiKey: string): JWT {
-    const client = new JWT(
-        {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
+  fromAPIKey(apiKey: string, options?: RefreshOptions): JWT {
+    options = options || {};
+    const client = new JWT(options);
     client.fromAPIKey(apiKey);
     return client;
   }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -84,7 +84,7 @@ export class GoogleAuth {
 
   cachedCredential: OAuth2Client|null = null;
 
-  private refreshTokenEarlyMillis: number|undefined;
+  private eagerRefreshThresholdMillis: number|undefined;
 
   /**
    * Export DefaultTransporter as a static property of the class.
@@ -93,7 +93,7 @@ export class GoogleAuth {
 
   constructor(options?: GoogleAuthOptions) {
     options = options || {};
-    this.refreshTokenEarlyMillis = options.refreshTokenEarlyMillis;
+    this.eagerRefreshThresholdMillis= options.eagerRefreshThresholdMillis;
   }
 
   /**
@@ -224,7 +224,7 @@ export class GoogleAuth {
         return {
           projectId: null,
           credential: new Compute(
-              {refreshTokenEarlyMillis: this.refreshTokenEarlyMillis})
+              {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis})
         };
       } else {
         // We failed to find the default credentials. Bail out with an error.
@@ -386,9 +386,9 @@ export class GoogleAuth {
     this.jsonContent = json;
     if (json.type === 'authorized_user') {
       client = new UserRefreshClient(
-          {refreshTokenEarlyMillis: this.refreshTokenEarlyMillis});
+          {eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     } else {
-      client = new JWT({refreshTokenEarlyMillis: this.refreshTokenEarlyMillis});
+      client = new JWT({eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     }
     client.fromJSON(json);
     return client;
@@ -443,7 +443,7 @@ export class GoogleAuth {
    */
   fromAPIKey(apiKey: string): JWT {
     const client =
-        new JWT({refreshTokenEarlyMillis: this.refreshTokenEarlyMillis});
+        new JWT({eagerRefreshThresholdMillis: this.eagerRefreshThresholdMillis});
     client.fromAPIKey(apiKey);
     return client;
   }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -29,7 +29,7 @@ import {JWTInput} from './credentials';
 import {IAMAuth} from './iam';
 import {JWTAccess} from './jwtaccess';
 import {JWT} from './jwtclient';
-import {OAuth2Client} from './oauth2client';
+import {OAuth2Client, RefreshOptions} from './oauth2client';
 import {UserRefreshClient} from './refreshclient';
 
 export interface ProjectIdCallback {
@@ -58,7 +58,7 @@ interface CredentialResult {
   default: {email: string;};
 }
 
-export interface GoogleAuthOptions { refreshTokenEarlyMillis?: number; }
+export interface GoogleAuthOptions extends RefreshOptions {}
 
 export class GoogleAuth {
   transporter: Transporter;

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -58,6 +58,8 @@ interface CredentialResult {
   default: {email: string;};
 }
 
+export interface GoogleAuthOptions { refreshTokenEarlyMillis?: number; }
+
 export class GoogleAuth {
   transporter: Transporter;
 
@@ -82,15 +84,17 @@ export class GoogleAuth {
 
   cachedCredential: OAuth2Client|null = null;
 
+  private refreshTokenEarlyMillis: number|undefined;
+
   /**
    * Export DefaultTransporter as a static property of the class.
    */
   static DefaultTransporter = DefaultTransporter;
 
-  /**
-   *  @param {number=} refreshTokenEarlyMillis The token should be refreshed if it will expire within this many milliseconds.
-   */
-  constructor(public refreshTokenEarlyMillis?: number) {}
+  constructor(options?: GoogleAuthOptions) {
+    options = options || {};
+    this.refreshTokenEarlyMillis = options.refreshTokenEarlyMillis;
+  }
 
   /**
    * Obtains the default project ID for the application..

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -62,7 +62,7 @@ export class JWT extends OAuth2Client {
     const opts = (optionsOrEmail && typeof optionsOrEmail === 'object') ?
         optionsOrEmail :
         {email: optionsOrEmail, keyFile, key, scopes, subject};
-    super({refreshTokenEarlyMillis: opts.refreshTokenEarlyMillis});
+    super({eagerRefreshThresholdMillis: opts.eagerRefreshThresholdMillis});
     this.email = opts.email;
     this.keyFile = opts.keyFile;
     this.key = opts.key;

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -19,17 +19,16 @@ import * as stream from 'stream';
 
 import {Credentials, JWTInput} from './credentials';
 import {JWTAccess} from './jwtaccess';
-import {GetTokenResponse, OAuth2Client, RequestMetadataResponse} from './oauth2client';
+import {GetTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';
 
 const isString = require('lodash.isstring');
 
-export interface JWTOptions {
+export interface JWTOptions extends RefreshOptions {
   email?: string;
   keyFile?: string;
   key?: string;
   scopes?: string|string[];
   subject?: string;
-  refreshTokenEarlyMillis?: number;
 }
 
 export class JWT extends OAuth2Client {

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -29,6 +29,7 @@ export interface JWTOptions {
   key?: string;
   scopes?: string|string[];
   subject?: string;
+  refreshTokenEarlyMillis?: number;
 }
 
 export class JWT extends OAuth2Client {
@@ -59,10 +60,10 @@ export class JWT extends OAuth2Client {
   constructor(
       optionsOrEmail?: string|JWTOptions, keyFile?: string, key?: string,
       scopes?: string|string[], subject?: string) {
-    super();
     const opts = (optionsOrEmail && typeof optionsOrEmail === 'object') ?
         optionsOrEmail :
         {email: optionsOrEmail, keyFile, key, scopes, subject};
+    super({refreshTokenEarlyMillis: opts.refreshTokenEarlyMillis});
     this.email = opts.email;
     this.keyFile = opts.keyFile;
     this.key = opts.key;

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -216,12 +216,17 @@ export interface VerifyIdTokenOptions {
   maxExpiry?: number;
 }
 
-export interface OAuth2ClientOptions {
+export interface OAuth2ClientOptions extends RefreshOptions {
   clientId?: string;
   clientSecret?: string;
   redirectUri?: string;
   authBaseUrl?: string;
   tokenUrl?: string;
+}
+
+export interface RefreshOptions {
+  // The token should be refreshed if it will expire within this many
+  // milliseconds.
   refreshTokenEarlyMillis?: number;
 }
 

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -227,7 +227,7 @@ export interface OAuth2ClientOptions extends RefreshOptions {
 export interface RefreshOptions {
   // Eagerly refresh unexpired tokens when they are within this many
   // milliseconds from expiring".
-  // Defaults to a value of 1000 (1 second).
+  // Defaults to a value of 300000 (5 minutes).
   eagerRefreshThresholdMillis?: number;
 }
 
@@ -282,7 +282,8 @@ export class OAuth2Client extends AuthClient {
     this.authBaseUrl = opts.authBaseUrl;
     this.tokenUrl = opts.tokenUrl;
     this.credentials = {};
-    this.eagerRefreshThresholdMillis = opts.eagerRefreshThresholdMillis || 1000;
+    this.eagerRefreshThresholdMillis =
+        opts.eagerRefreshThresholdMillis || 5 * 60 * 1000;
   }
 
   /**

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -225,8 +225,8 @@ export interface OAuth2ClientOptions extends RefreshOptions {
 }
 
 export interface RefreshOptions {
-  // Eagerly refresh unexpired tokens when they are within this many 
-  // milliseconds from expiring". 
+  // Eagerly refresh unexpired tokens when they are within this many
+  // milliseconds from expiring".
   // Defaults to a value of 1000 (1 second).
   eagerRefreshThresholdMillis?: number;
 }
@@ -259,7 +259,7 @@ export class OAuth2Client extends AuthClient {
    * @param {Object=} opts optional options for overriding the given parameters.
    * @constructor
    */
-  constructor(options: OAuth2ClientOptions);
+  constructor(options?: OAuth2ClientOptions);
   constructor(
       clientId?: string, clientSecret?: string, redirectUri?: string,
       opts?: AuthClientOpts);
@@ -282,7 +282,7 @@ export class OAuth2Client extends AuthClient {
     this.authBaseUrl = opts.authBaseUrl;
     this.tokenUrl = opts.tokenUrl;
     this.credentials = {};
-    this.eagerRefreshThresholdMillis= opts.eagerRefreshThresholdMillis|| 1000;
+    this.eagerRefreshThresholdMillis = opts.eagerRefreshThresholdMillis || 1000;
   }
 
   /**
@@ -935,14 +935,14 @@ export class OAuth2Client extends AuthClient {
   }
 
   /**
-   * Returns true iff a token is expired or will expire within
+   * Returns true if a token is expired or will expire within
    * eagerRefreshThresholdMillismilliseconds.
    * If there is no expiry time, assumes the token is not expired or expiring.
    */
   protected isTokenExpiring(): boolean {
     const expiryDate = this.credentials.expiry_date;
-    return expiryDate ?
-        expiryDate <= ((new Date()).getTime() + this.eagerRefreshThresholdMillis) :
-        false;
+    return expiryDate ? expiryDate <=
+            ((new Date()).getTime() + this.eagerRefreshThresholdMillis) :
+                        false;
   }
 }

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -225,9 +225,10 @@ export interface OAuth2ClientOptions extends RefreshOptions {
 }
 
 export interface RefreshOptions {
-  // The token should be refreshed if it will expire within this many
-  // milliseconds.
-  refreshTokenEarlyMillis?: number;
+  // Eagerly refresh unexpired tokens when they are within this many 
+  // milliseconds from expiring". 
+  // Defaults to a value of 1000 (1 second).
+  eagerRefreshThresholdMillis?: number;
 }
 
 export class OAuth2Client extends AuthClient {
@@ -247,7 +248,7 @@ export class OAuth2Client extends AuthClient {
 
   projectId?: string;
 
-  refreshTokenEarlyMillis: number;
+  eagerRefreshThresholdMillis: number;
 
   /**
    * Handles OAuth2 flow for Google APIs.
@@ -281,7 +282,7 @@ export class OAuth2Client extends AuthClient {
     this.authBaseUrl = opts.authBaseUrl;
     this.tokenUrl = opts.tokenUrl;
     this.credentials = {};
-    this.refreshTokenEarlyMillis = opts.refreshTokenEarlyMillis || 0;
+    this.eagerRefreshThresholdMillis= opts.eagerRefreshThresholdMillis|| 1000;
   }
 
   /**
@@ -935,13 +936,13 @@ export class OAuth2Client extends AuthClient {
 
   /**
    * Returns true iff a token is expired or will expire within
-   * refreshTokenEarlyMillis milliseconds.
+   * eagerRefreshThresholdMillismilliseconds.
    * If there is no expiry time, assumes the token is not expired or expiring.
    */
   protected isTokenExpiring(): boolean {
     const expiryDate = this.credentials.expiry_date;
     return expiryDate ?
-        expiryDate <= ((new Date()).getTime() + this.refreshTokenEarlyMillis) :
+        expiryDate <= ((new Date()).getTime() + this.eagerRefreshThresholdMillis) :
         false;
   }
 }

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -38,13 +38,9 @@ export class UserRefreshClient extends OAuth2Client {
    * @param {string} refreshToken The authentication refresh token.
    * @constructor
    */
-  constructor(
-      clientId?: string, clientSecret?: string, refreshToken?: string,
-      eagerRefreshThresholdMillis?: number);
+  constructor(clientId?: string, clientSecret?: string, refreshToken?: string);
   constructor(options: UserRefreshClientOptions);
-  constructor(
-      clientId?: string, clientSecret?: string, refreshToken?: string,
-      eagerRefreshThresholdMillis?: number);
+  constructor(clientId?: string, clientSecret?: string, refreshToken?: string);
   constructor(
       optionsOrClientId?: string|UserRefreshClientOptions,
       clientSecret?: string, refreshToken?: string,

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -32,8 +32,10 @@ export class UserRefreshClient extends OAuth2Client {
    * @param {string} refreshToken The authentication refresh token.
    * @constructor
    */
-  constructor(clientId?: string, clientSecret?: string, refreshToken?: string) {
-    super(clientId, clientSecret);
+  constructor(
+      clientId?: string, clientSecret?: string, refreshToken?: string,
+      refreshTokenEarlyMillis?: number) {
+    super({clientId, clientSecret, refreshTokenEarlyMillis});
     this._refreshToken = refreshToken;
   }
 

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -16,15 +16,13 @@
 
 import * as stream from 'stream';
 import {JWTInput} from './credentials';
-import {GetTokenResponse, OAuth2Client} from './oauth2client';
+import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
-export interface UserRefreshClientOptions {
+export interface UserRefreshClientOptions extends RefreshOptions {
   clientId?: string;
   clientSecret?: string;
   refreshToken?: string;
-  refreshTokenEarlyMillis?: number;
 }
-
 
 export class UserRefreshClient extends OAuth2Client {
   // TODO: refactor tests to make this private
@@ -43,7 +41,6 @@ export class UserRefreshClient extends OAuth2Client {
   constructor(
       clientId?: string, clientSecret?: string, refreshToken?: string,
       refreshTokenEarlyMillis?: number);
-
   constructor(options: UserRefreshClientOptions);
   constructor(
       clientId?: string, clientSecret?: string, refreshToken?: string,

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -40,27 +40,27 @@ export class UserRefreshClient extends OAuth2Client {
    */
   constructor(
       clientId?: string, clientSecret?: string, refreshToken?: string,
-      refreshTokenEarlyMillis?: number);
+      eagerRefreshThresholdMillis?: number);
   constructor(options: UserRefreshClientOptions);
   constructor(
       clientId?: string, clientSecret?: string, refreshToken?: string,
-      refreshTokenEarlyMillis?: number);
+      eagerRefreshThresholdMillis?: number);
   constructor(
       optionsOrClientId?: string|UserRefreshClientOptions,
       clientSecret?: string, refreshToken?: string,
-      refreshTokenEarlyMillis?: number) {
+      eagerRefreshThresholdMillis?: number) {
     const opts = (optionsOrClientId && typeof optionsOrClientId === 'object') ?
         optionsOrClientId :
         {
           clientId: optionsOrClientId,
           clientSecret,
           refreshToken,
-          refreshTokenEarlyMillis
+          eagerRefreshThresholdMillis
         };
     super({
       clientId: opts.clientId,
       clientSecret: opts.clientSecret,
-      refreshTokenEarlyMillis: opts.refreshTokenEarlyMillis
+      eagerRefreshThresholdMillis: opts.eagerRefreshThresholdMillis
     });
     this._refreshToken = opts.refreshToken;
   }

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -18,6 +18,14 @@ import * as stream from 'stream';
 import {JWTInput} from './credentials';
 import {GetTokenResponse, OAuth2Client} from './oauth2client';
 
+export interface UserRefreshClientOptions {
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  refreshTokenEarlyMillis?: number;
+}
+
+
 export class UserRefreshClient extends OAuth2Client {
   // TODO: refactor tests to make this private
   // In a future gts release, the _propertyName rule will be lifted.
@@ -34,9 +42,30 @@ export class UserRefreshClient extends OAuth2Client {
    */
   constructor(
       clientId?: string, clientSecret?: string, refreshToken?: string,
+      refreshTokenEarlyMillis?: number);
+
+  constructor(options: UserRefreshClientOptions);
+  constructor(
+      clientId?: string, clientSecret?: string, refreshToken?: string,
+      refreshTokenEarlyMillis?: number);
+  constructor(
+      optionsOrClientId?: string|UserRefreshClientOptions,
+      clientSecret?: string, refreshToken?: string,
       refreshTokenEarlyMillis?: number) {
-    super({clientId, clientSecret, refreshTokenEarlyMillis});
-    this._refreshToken = refreshToken;
+    const opts = (optionsOrClientId && typeof optionsOrClientId === 'object') ?
+        optionsOrClientId :
+        {
+          clientId: optionsOrClientId,
+          clientSecret,
+          refreshToken,
+          refreshTokenEarlyMillis
+        };
+    super({
+      clientId: opts.clientId,
+      clientSecret: opts.clientSecret,
+      refreshTokenEarlyMillis: opts.refreshTokenEarlyMillis
+    });
+    this._refreshToken = opts.refreshToken;
   }
 
   /**

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -70,7 +70,7 @@ describe('Compute auth client', () => {
     nock('http://metadata.google.internal')
         .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
         .reply(200, {access_token: 'abc123', expires_in: 10000});
-    compute = new Compute(10000);
+    compute = new Compute({refreshTokenEarlyMillis: 10000});
     compute.credentials.access_token = 'initial-access-token';
     compute.credentials.expiry_date = (new Date()).getTime() + 5000;
     compute.request({url: 'http://foo'}, () => {

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -66,6 +66,19 @@ describe('Compute auth client', () => {
     });
   });
 
+  it('should refresh if access token has expired', (done) => {
+    nock('http://metadata.google.internal')
+        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
+        .reply(200, {access_token: 'abc123', expires_in: 10000});
+    compute = new Compute(10000);
+    compute.credentials.access_token = 'initial-access-token';
+    compute.credentials.expiry_date = (new Date()).getTime() + 5000;
+    compute.request({url: 'http://foo'}, () => {
+      assert.equal(compute.credentials.access_token, 'abc123');
+      done();
+    });
+  });
+
   it('should not refresh if access token has not expired', (done) => {
     const scope =
         nock('http://metadata.google.internal')

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -90,8 +90,9 @@ describe('Compute auth client', () => {
                .get(
                    '/computeMetadata/v1beta1/instance/service-accounts/default/token')
                .reply(200, {access_token: 'abc123', expires_in: 10000});
+       compute = new Compute({eagerRefreshThresholdMillis: 1000});
        compute.credentials.access_token = 'initial-access-token';
-       compute.credentials.expiry_date = (new Date()).getTime() + 11000;
+       compute.credentials.expiry_date = (new Date()).getTime() + 12000;
        compute.request({url: 'http://foo'}, () => {
          assert.equal(compute.credentials.access_token, 'initial-access-token');
          assert.equal(false, scope.isDone());
@@ -107,7 +108,7 @@ describe('Compute auth client', () => {
                 '/computeMetadata/v1beta1/instance/service-accounts/default/token')
             .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.credentials.access_token = 'initial-access-token';
-    compute.credentials.expiry_date = (new Date()).getTime() + 10000;
+    compute.credentials.expiry_date = (new Date()).getTime() + 10 * 60 * 1000;
     compute.request({url: 'http://foo'}, () => {
       assert.equal(compute.credentials.access_token, 'initial-access-token');
       assert.equal(false, scope.isDone());

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -73,7 +73,7 @@ describe('Compute auth client', () => {
            .get(
                '/computeMetadata/v1beta1/instance/service-accounts/default/token')
            .reply(200, {access_token: 'abc123', expires_in: 10000});
-       compute = new Compute({refreshTokenEarlyMillis: 10000});
+       compute = new Compute({eagerRefreshThresholdMillis: 10000});
        compute.credentials.access_token = 'initial-access-token';
        compute.credentials.expiry_date = (new Date()).getTime() + 5000;
        compute.request({url: 'http://foo'}, () => {

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -66,18 +66,39 @@ describe('Compute auth client', () => {
     });
   });
 
-  it('should refresh if access token has expired', (done) => {
-    nock('http://metadata.google.internal')
-        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
-        .reply(200, {access_token: 'abc123', expires_in: 10000});
-    compute = new Compute({refreshTokenEarlyMillis: 10000});
-    compute.credentials.access_token = 'initial-access-token';
-    compute.credentials.expiry_date = (new Date()).getTime() + 5000;
-    compute.request({url: 'http://foo'}, () => {
-      assert.equal(compute.credentials.access_token, 'abc123');
-      done();
-    });
-  });
+  it('should refresh if access token will expired soon and time to refresh' +
+         ' before expiration is set',
+     (done) => {
+       nock('http://metadata.google.internal')
+           .get(
+               '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+           .reply(200, {access_token: 'abc123', expires_in: 10000});
+       compute = new Compute({refreshTokenEarlyMillis: 10000});
+       compute.credentials.access_token = 'initial-access-token';
+       compute.credentials.expiry_date = (new Date()).getTime() + 5000;
+       compute.request({url: 'http://foo'}, () => {
+         assert.equal(compute.credentials.access_token, 'abc123');
+         done();
+       });
+     });
+
+  it('should not refresh if access token will not expire soon and time to' +
+         ' refresh before expiration is set',
+     (done) => {
+       const scope =
+           nock('http://metadata.google.internal')
+               .get(
+                   '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+               .reply(200, {access_token: 'abc123', expires_in: 10000});
+       compute.credentials.access_token = 'initial-access-token';
+       compute.credentials.expiry_date = (new Date()).getTime() + 11000;
+       compute.request({url: 'http://foo'}, () => {
+         assert.equal(compute.credentials.access_token, 'initial-access-token');
+         assert.equal(false, scope.isDone());
+         nock.cleanAll();
+         done();
+       });
+     });
 
   it('should not refresh if access token has not expired', (done) => {
     const scope =
@@ -165,8 +186,8 @@ describe('Compute auth client', () => {
              .twice()
              .reply(403, 'a weird response body');
 
-         // Mock the credentials object with a null access token, to force a
-         // refresh.
+         // Mock the credentials object with a null access token, to force
+         // a refresh.
          compute.credentials = {
            refresh_token: 'hello',
            access_token: undefined,
@@ -193,8 +214,8 @@ describe('Compute auth client', () => {
                  '/computeMetadata/v1beta1/instance/service-accounts/default/token')
              .reply(404, 'a weird body');
 
-         // Mock the credentials object with a null access token, to force a
-         // refresh.
+         // Mock the credentials object with a null access token, to force
+         // a refresh.
          compute.credentials = {
            refresh_token: 'hello',
            access_token: undefined,

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -328,7 +328,16 @@ describe('GoogleAuth', () => {
              ' set for GoogleAuth',
          () => {
            const json = createJwtJSON();
-           const auth = new GoogleAuth({eagerRefreshThresholdMillis: 1000});
+           const auth = new GoogleAuth();
+           auth.setEagerRefreshThresholdMillis(5000);
+           const result = auth.fromJSON(json);
+           assert.equal(5000, (result as JWT).eagerRefreshThresholdMillis);
+         });
+
+      it('should create JWT with 1s as value for eagerRefreshThresholdMillis',
+         () => {
+           const json = createJwtJSON();
+           const auth = new GoogleAuth();
            const result = auth.fromJSON(json);
            assert.equal(1000, (result as JWT).eagerRefreshThresholdMillis);
          });

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -258,6 +258,14 @@ describe('GoogleAuth', () => {
                    });
              });
         });
+
+        describe('With eager retry', () => {
+          it('should make client with eagerRetryThresholdMillis set', () => {
+            const client =
+                auth.fromAPIKey(API_KEY, {eagerRefreshThresholdMillis: 100});
+            assert.equal(100, client.eagerRefreshThresholdMillis);
+          });
+        });
       });
     });
 
@@ -329,8 +337,8 @@ describe('GoogleAuth', () => {
          () => {
            const json = createJwtJSON();
            const auth = new GoogleAuth();
-           auth.setEagerRefreshThresholdMillis(5000);
-           const result = auth.fromJSON(json);
+           const result =
+               auth.fromJSON(json, {eagerRefreshThresholdMillis: 5000});
            assert.equal(5000, (result as JWT).eagerRefreshThresholdMillis);
          });
 
@@ -415,6 +423,31 @@ describe('GoogleAuth', () => {
       });
     });
 
+
+    it('should read the stream and create a jwt with eager refresh',
+       async () => {
+         // Read the contents of the file into a json object.
+         const fileContents =
+             fs.readFileSync('./test/fixtures/private.json', 'utf-8');
+         const json = JSON.parse(fileContents);
+
+         // Now open a stream on the same file.
+         const stream = fs.createReadStream('./test/fixtures/private.json');
+
+         // And pass it into the fromStream method.
+         const auth = new GoogleAuth();
+         const result = await auth.fromStream(
+             stream, {eagerRefreshThresholdMillis: 1000 * 60 * 60});
+         const jwt = result as JWT;
+         // Ensure that the correct bits were pulled from the stream.
+         assert.equal(json.private_key, jwt.key);
+         assert.equal(json.client_email, jwt.email);
+         assert.equal(null, jwt.keyFile);
+         assert.equal(null, jwt.subject);
+         assert.equal(null, jwt.scope);
+         assert.equal(1000 * 60 * 60, jwt.eagerRefreshThresholdMillis);
+       });
+
     it('should read another stream and create a UserRefreshClient', (done) => {
       // Read the contents of the file into a json object.
       const fileContents =
@@ -436,6 +469,28 @@ describe('GoogleAuth', () => {
         done();
       });
     });
+
+    it('should read another stream and create a UserRefreshClient with eager refresh',
+       async () => {
+         // Read the contents of the file into a json object.
+         const fileContents =
+             fs.readFileSync('./test/fixtures/refresh.json', 'utf-8');
+         const json = JSON.parse(fileContents);
+
+         // Now open a stream on the same file.
+         const stream = fs.createReadStream('./test/fixtures/refresh.json');
+
+         // And pass it into the fromStream method.
+         const auth = new GoogleAuth();
+         const result =
+             await auth.fromStream(stream, {eagerRefreshThresholdMillis: 100});
+         // Ensure that the correct bits were pulled from the stream.
+         const rc = result as UserRefreshClient;
+         assert.equal(json.client_id, rc._clientId);
+         assert.equal(json.client_secret, rc._clientSecret);
+         assert.equal(json.refresh_token, rc._refreshToken);
+         assert.equal(100, rc.eagerRefreshThresholdMillis);
+       });
   });
 
   describe('._getApplicationCredentialsFromFilePath', () => {
@@ -593,6 +648,28 @@ describe('GoogleAuth', () => {
       assert.equal(null, jwt.subject);
       assert.equal(null, jwt.scope);
     });
+
+    it('should correctly read the file and create a valid JWT with eager refresh',
+       async () => {
+         // Read the contents of the file into a json object.
+         const fileContents =
+             fs.readFileSync('./test/fixtures/private.json', 'utf-8');
+         const json = JSON.parse(fileContents);
+
+         // Now pass the same path to the auth loader.
+         const auth = new GoogleAuth();
+         const result = await auth._getApplicationCredentialsFromFilePath(
+             './test/fixtures/private.json',
+             {eagerRefreshThresholdMillis: 7000});
+         assert(result);
+         const jwt = result as JWT;
+         assert.equal(json.private_key, jwt.key);
+         assert.equal(json.client_email, jwt.email);
+         assert.equal(null, jwt.keyFile);
+         assert.equal(null, jwt.subject);
+         assert.equal(null, jwt.scope);
+         assert.equal(7000, jwt.eagerRefreshThresholdMillis);
+       });
   });
 
   describe('._tryGetApplicationCredentialsFromEnvironmentVariable', () => {
@@ -651,6 +728,32 @@ describe('GoogleAuth', () => {
       assert.equal(null, jwt.subject);
       assert.equal(null, jwt.scope);
     });
+
+    it('should handle valid environment variable when there is eager refresh set',
+       async () => {
+         // Set up a mock to return path to a valid credentials file.
+         const auth = new GoogleAuth();
+         insertEnvironmentVariableIntoAuth(
+             auth, 'GOOGLE_APPLICATION_CREDENTIALS',
+             './test/fixtures/private.json');
+
+         // Read the contents of the file into a json object.
+         const fileContents =
+             fs.readFileSync('./test/fixtures/private.json', 'utf-8');
+         const json = JSON.parse(fileContents);
+
+         // Execute.
+         const result =
+             await auth._tryGetApplicationCredentialsFromEnvironmentVariable(
+                 {eagerRefreshThresholdMillis: 60 * 60 * 1000});
+         const jwt = result as JWT;
+         assert.equal(json.private_key, jwt.key);
+         assert.equal(json.client_email, jwt.email);
+         assert.equal(null, jwt.keyFile);
+         assert.equal(null, jwt.subject);
+         assert.equal(null, jwt.scope);
+         assert.equal(60 * 60 * 1000, jwt.eagerRefreshThresholdMillis);
+       });
   });
 
   describe('._tryGetApplicationCredentialsFromWellKnownFile', () => {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -324,13 +324,13 @@ describe('GoogleAuth', () => {
         assert.equal(null, (result as JWT).keyFile);
       });
 
-      it('should create JWT which refreshTokenEarlyMillis set when this is' +
+      it('should create JWT which eagerRefreshThresholdMillisset when this is' +
              ' set for GoogleAuth',
          () => {
            const json = createJwtJSON();
-           const auth = new GoogleAuth({refreshTokenEarlyMillis: 1000});
+           const auth = new GoogleAuth({eagerRefreshThresholdMillis: 1000});
            const result = auth.fromJSON(json);
-           assert.equal(1000, (result as JWT).refreshTokenEarlyMillis);
+           assert.equal(1000, (result as JWT).eagerRefreshThresholdMillis);
          });
     });
 

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -334,12 +334,12 @@ describe('GoogleAuth', () => {
            assert.equal(5000, (result as JWT).eagerRefreshThresholdMillis);
          });
 
-      it('should create JWT with 1s as value for eagerRefreshThresholdMillis',
+      it('should create JWT with 5min as value for eagerRefreshThresholdMillis',
          () => {
            const json = createJwtJSON();
            const auth = new GoogleAuth();
            const result = auth.fromJSON(json);
-           assert.equal(1000, (result as JWT).eagerRefreshThresholdMillis);
+           assert.equal(300000, (result as JWT).eagerRefreshThresholdMillis);
          });
     });
 

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -323,6 +323,15 @@ describe('GoogleAuth', () => {
         const result = auth.fromJSON(json);
         assert.equal(null, (result as JWT).keyFile);
       });
+
+      it('should create JWT which refreshTokenEarlyMillis set when this is' +
+             ' set for GoogleAuth',
+         () => {
+           const json = createJwtJSON();
+           const auth = new GoogleAuth(1000);
+           const result = auth.fromJSON(json);
+           assert.equal(1000, (result as JWT).refreshTokenEarlyMillis);
+         });
     });
 
     describe('Refresh token', () => {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -328,7 +328,7 @@ describe('GoogleAuth', () => {
              ' set for GoogleAuth',
          () => {
            const json = createJwtJSON();
-           const auth = new GoogleAuth(1000);
+           const auth = new GoogleAuth({refreshTokenEarlyMillis: 1000});
            const result = auth.fromJSON(json);
            assert.equal(1000, (result as JWT).refreshTokenEarlyMillis);
          });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -227,6 +227,7 @@ describe('JWT auth client', () => {
         done();
       });
     });
+
     it('should refresh if access token will expired soon and time to refresh' +
            ' before expiration is set',
        (done) => {
@@ -248,6 +249,35 @@ describe('JWT auth client', () => {
          createGTokenMock({access_token: 'abc123'});
          jwt.request({url: 'http://bar'}, () => {
            assert.equal('abc123', jwt.credentials.access_token);
+           done();
+         });
+       });
+
+    it('should not refresh if access token will not expire soon and time to' +
+           ' refresh before expiration is set',
+       (done) => {
+         const scope =
+             nock('https://accounts.google.com')
+                 .post('/o/oauth2/token', '*')
+                 .reply(200, {access_token: 'abc123', expires_in: 10000});
+
+         const jwt = new JWT({
+           email: 'foo@serviceaccount.com',
+           keyFile: '/path/to/key.pem',
+           scopes: ['http://bar', 'http://foo'],
+           subject: 'bar@subjectaccount.com',
+           refreshTokenEarlyMillis: 1000
+         });
+
+         jwt.credentials = {
+           access_token: 'initial-access-token',
+           refresh_token: 'jwt-placeholder',
+           expiry_date: (new Date()).getTime() + 5000
+         };
+
+         jwt.request({url: 'http://bar'}, () => {
+           assert.equal('initial-access-token', jwt.credentials.access_token);
+           assert.equal(false, scope.isDone());
            done();
          });
        });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -227,6 +227,30 @@ describe('JWT auth client', () => {
         done();
       });
     });
+    it('should refresh if access token will expired soon and time to refresh' +
+           ' before expiration is set',
+       (done) => {
+         const auth = new GoogleAuth();
+         const jwt = new JWT({
+           email: 'foo@serviceaccount.com',
+           keyFile: PEM_PATH,
+           scopes: ['http://bar', 'http://foo'],
+           subject: 'bar@subjectaccount.com',
+           refreshTokenEarlyMillis: 1000
+         });
+
+         jwt.credentials = {
+           access_token: 'woot',
+           refresh_token: 'jwt-placeholder',
+           expiry_date: (new Date()).getTime() + 800
+         };
+
+         createGTokenMock({access_token: 'abc123'});
+         jwt.request({url: 'http://bar'}, () => {
+           assert.equal('abc123', jwt.credentials.access_token);
+           done();
+         });
+       });
 
     it('should refresh token if the server returns 403', (done) => {
       nock('http://example.com').get('/access').twice().reply(403);

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -237,7 +237,7 @@ describe('JWT auth client', () => {
            keyFile: PEM_PATH,
            scopes: ['http://bar', 'http://foo'],
            subject: 'bar@subjectaccount.com',
-           refreshTokenEarlyMillis: 1000
+           eagerRefreshThresholdMillis: 1000
          });
 
          jwt.credentials = {
@@ -266,7 +266,7 @@ describe('JWT auth client', () => {
            keyFile: '/path/to/key.pem',
            scopes: ['http://bar', 'http://foo'],
            subject: 'bar@subjectaccount.com',
-           refreshTokenEarlyMillis: 1000
+           eagerRefreshThresholdMillis: 1000
          });
 
          jwt.credentials = {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1051,6 +1051,29 @@ describe('OAuth2 client', () => {
          });
        });
 
+    it('should not refresh if access token will not expire soon and time to' +
+           ' refresh before expiration is set',
+       (done) => {
+         const oauth2client = new OAuth2Client({
+           clientId: CLIENT_ID,
+           clientSecret: CLIENT_SECRET,
+           redirectUri: REDIRECT_URI,
+           refreshTokenEarlyMillis: 5000
+         });
+
+         oauth2client.credentials = {
+           access_token: 'initial-access-token',
+           refresh_token: 'refresh-token-placeholder',
+           expiry_date: (new Date()).getTime() + 10000,
+         };
+
+         oauth2client.request({url: 'http://example.com'}, () => {
+           assert.equal(
+               'initial-access-token', oauth2client.credentials.access_token);
+           assert.equal(false, scope.isDone());
+           done();
+         });
+       });
 
     it('should not refresh if not expired', (done) => {
       const oauth2client =

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1030,7 +1030,7 @@ describe('OAuth2 client', () => {
 
     it('should refresh if access token will expired soon and time to refresh' +
            ' before expiration is set',
-       (done) => {
+       async () => {
          const auth = new GoogleAuth();
          const oauth2client = new OAuth2Client({
            clientId: CLIENT_ID,
@@ -1045,15 +1045,13 @@ describe('OAuth2 client', () => {
            expiry_date: (new Date()).getTime() + 3000
          };
 
-         oauth2client.request({url: 'http://example.com'}, () => {
-           assert.equal('abc123', oauth2client.credentials.access_token);
-           done();
-         });
+         await oauth2client.request({url: 'http://example.com'});
+         assert.equal('abc123', oauth2client.credentials.access_token);
        });
 
     it('should not refresh if access token will not expire soon and time to' +
            ' refresh before expiration is set',
-       (done) => {
+       async () => {
          const oauth2client = new OAuth2Client({
            clientId: CLIENT_ID,
            clientSecret: CLIENT_SECRET,
@@ -1067,12 +1065,11 @@ describe('OAuth2 client', () => {
            expiry_date: (new Date()).getTime() + 10000,
          };
 
-         oauth2client.request({url: 'http://example.com'}, () => {
-           assert.equal(
-               'initial-access-token', oauth2client.credentials.access_token);
-           assert.equal(false, scope.isDone());
-           done();
-         });
+         await oauth2client.request({url: 'http://example.com'});
+
+         assert.equal(
+             'initial-access-token', oauth2client.credentials.access_token);
+         assert.equal(false, scope.isDone());
        });
 
     it('should not refresh if not expired', (done) => {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1079,7 +1079,7 @@ describe('OAuth2 client', () => {
       oauth2client.credentials = {
         access_token: 'initial-access-token',
         refresh_token: 'refresh-token-placeholder',
-        expiry_date: (new Date()).getTime() + 1500
+        expiry_date: (new Date()).getTime() + 500000
       };
 
       oauth2client.request({url: 'http://example.com'}, () => {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1036,7 +1036,7 @@ describe('OAuth2 client', () => {
            clientId: CLIENT_ID,
            clientSecret: CLIENT_SECRET,
            redirectUri: REDIRECT_URI,
-           refreshTokenEarlyMillis: 5000
+           eagerRefreshThresholdMillis: 5000
          });
 
          oauth2client.credentials = {
@@ -1058,7 +1058,7 @@ describe('OAuth2 client', () => {
            clientId: CLIENT_ID,
            clientSecret: CLIENT_SECRET,
            redirectUri: REDIRECT_URI,
-           refreshTokenEarlyMillis: 5000
+           eagerRefreshThresholdMillis: 5000
          });
 
          oauth2client.credentials = {
@@ -1082,7 +1082,7 @@ describe('OAuth2 client', () => {
       oauth2client.credentials = {
         access_token: 'initial-access-token',
         refresh_token: 'refresh-token-placeholder',
-        expiry_date: (new Date()).getTime() + 1000
+        expiry_date: (new Date()).getTime() + 1500
       };
 
       oauth2client.request({url: 'http://example.com'}, () => {

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1027,6 +1027,31 @@ describe('OAuth2 client', () => {
       });
     });
 
+
+    it('should refresh if access token will expired soon and time to refresh' +
+           ' before expiration is set',
+       (done) => {
+         const auth = new GoogleAuth();
+         const oauth2client = new OAuth2Client({
+           clientId: CLIENT_ID,
+           clientSecret: CLIENT_SECRET,
+           redirectUri: REDIRECT_URI,
+           refreshTokenEarlyMillis: 5000
+         });
+
+         oauth2client.credentials = {
+           access_token: 'initial-access-token',
+           refresh_token: 'refresh-token-placeholder',
+           expiry_date: (new Date()).getTime() + 3000
+         };
+
+         oauth2client.request({url: 'http://example.com'}, () => {
+           assert.equal('abc123', oauth2client.credentials.access_token);
+           done();
+         });
+       });
+
+
     it('should not refresh if not expired', (done) => {
       const oauth2client =
           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);


### PR DESCRIPTION
This pull request makes it possible to refresh the token when it is not expired but will expire in some period of time.
This can be used to address the issues described in #133, by allowing users to specify that tokens should be refreshed if they will expire soon. This is also necessary to fix GoogleCloudPlatform/cloud-profiler-nodejs#94

For earlier discussion of these changes, see PR #208.