### PR TITLE
fix: use npm link to run samples

### DIFF
--- a/examples/adc.js
+++ b/examples/adc.js
@@ -22,7 +22,7 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const { GoogleAuth } = require('../build/src/index');
+const { GoogleAuth } = require('google-auth-library');
 const auth = new GoogleAuth();
 
 /**

--- a/examples/fromJSON.js
+++ b/examples/fromJSON.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { GoogleAuth } = require('../build/src/index');
+const { GoogleAuth } = require('google-auth-library');
 
 /**
  * Instead of loading credentials from a key file, you can also provide

--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { JWT } = require('../build/src/index');
+const { JWT } = require('google-auth-library');
 
 /**
  * The JWT authorization is ideal for performing server-to-server

--- a/examples/keepalive.js
+++ b/examples/keepalive.js
@@ -23,7 +23,7 @@
 /**
  * Import the GoogleAuth library, and create a new GoogleAuth client.
  */
-const { GoogleAuth } = require('../build/src/index');
+const { GoogleAuth } = require('google-auth-library');
 const auth = new GoogleAuth();
 const https = require('https');
 

--- a/examples/oauth2-codeVerifier.js
+++ b/examples/oauth2-codeVerifier.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { OAuth2Client } = require('../build/src/index');
+const { OAuth2Client } = require('google-auth-library');
 const http = require('http');
 const url = require('url');
 const querystring = require('querystring');

--- a/examples/oauth2.js
+++ b/examples/oauth2.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { OAuth2Client } = require('../build/src/index');
+const { OAuth2Client } = require('google-auth-library');
 const http = require('http');
 const url = require('url');
 const querystring = require('querystring');

--- a/examples/refreshAccessToken.js
+++ b/examples/refreshAccessToken.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { OAuth2Client } = require('../build/src/index');
+const { OAuth2Client } = require('google-auth-library');
 const http = require('http');
 const url = require('url');
 const querystring = require('querystring');

--- a/examples/verifyIdToken.js
+++ b/examples/verifyIdToken.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { OAuth2Client } = require('../build/src/index');
+const { OAuth2Client } = require('google-auth-library');
 const http = require('http');
 const url = require('url');
 const querystring = require('querystring');


### PR DESCRIPTION
An issue came up in #244 where the user is confused by the imported npm module.  I was previously reaching directly up to the index module, but with this fix we now will just use `npm link && npm link google-auth-library` to run the samples against the current working directory. 