### PR TITLE
feat: add IAP and additional claims support

### DIFF
--- a/examples/iap.js
+++ b/examples/iap.js
@@ -1,0 +1,41 @@
+// Copyright 2017, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { JWT } = require('google-auth-library');
+
+/**
+ * The JWT authorization is ideal for performing server-to-server
+ * communication without asking for user consent.
+ *
+ * Suggested reading for Admin SDK users using service accounts:
+ * https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+ **/
+
+const keys = require('./jwt.keys.json');
+const oauth2Keys = require('./iap.keys.json');
+
+async function main() {
+  const clientId = oauth2Keys.web.client_id;
+  const client = new JWT({
+    email: keys.client_email,
+    key: keys.private_key,
+    additionalClaims: { target_audience: clientId }
+  });
+  const url = `https://iap-demo-dot-el-gato.appspot.com`;
+  const res = await client.request({ url });
+  console.log(res.data);
+}
+
+main().catch(console.error);

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -18,7 +18,7 @@ import * as jws from 'jws';
 import * as LRU from 'lru-cache';
 import * as stream from 'stream';
 import {JWTInput} from './credentials';
-import {RequestMetadataCallback, RequestMetadataResponse} from './oauth2client';
+import {RequestMetadataResponse} from './oauth2client';
 
 export class JWTAccess {
   email?: string|null;
@@ -74,6 +74,8 @@ export class JWTAccess {
     // The payload used for signed JWT headers has:
     // iss == sub == <client email>
     // aud == <the authorization uri>
+    // NOTE: Users can also override the values for iss / sub / aud / etc
+    // with additionalClaims.
     const payload = Object.assign(
         {iss: this.email, sub: this.email, aud: authURI, exp, iat},
         additionalClaims);

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -57,10 +57,13 @@ export class JWTAccess {
   /**
    * Get a non-expired access token, after refreshing if necessary.
    *
-   * @param {string} authURI the URI being authorized
+   * @param authURI The URI being authorized.
+   * @param additionalClaims An object with a set of additional claims to
+   * include in the payload.
    * @returns An object that includes the authorization header.
    */
-  getRequestMetadata(authURI: string): RequestMetadataResponse {
+  getRequestMetadata(authURI: string, additionalClaims?: {}):
+      RequestMetadataResponse {
     const cachedToken = this.cache.get(authURI);
     if (cachedToken) {
       return cachedToken;
@@ -71,12 +74,9 @@ export class JWTAccess {
     // The payload used for signed JWT headers has:
     // iss == sub == <client email>
     // aud == <the authorization uri>
-    const payload = {iss: this.email, sub: this.email, aud: authURI, exp, iat};
-    const assertion = {
-      header: {alg: 'RS256'} as jws.Header,
-      payload,
-      secret: this.key
-    };
+    const payload = Object.assign(
+        {iss: this.email, sub: this.email, aud: authURI, exp, iat},
+        additionalClaims);
 
     // Sign the jwt and add it to the cache
     const signedJWT =

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -72,23 +72,24 @@ export class JWTAccess {
     const iat = Math.floor(new Date().getTime() / 1000);
     const exp = iat + 3600;  // 3600 seconds = 1 hour
 
+    // The payload used for signed JWT headers has:
+    // iss == sub == <client email>
+    // aud == <the authorization uri>
+    const defaultClaims =
+        {iss: this.email, sub: this.email, aud: authURI, exp, iat};
+
     // if additionalClaims are provided, ensure they do not collide with
     // other required claims.
     if (additionalClaims) {
-      ['iss', 'sub', 'aud', 'exp', 'iat'].forEach(claim => {
+      for (const claim in defaultClaims) {
         if (additionalClaims[claim]) {
           throw new Error(`The '${
               claim}' property is not allowed when passing additionalClaims. This claim is included in the JWT by default.`);
         }
-      });
+      }
     }
 
-    // The payload used for signed JWT headers has:
-    // iss == sub == <client email>
-    // aud == <the authorization uri>
-    const payload = Object.assign(
-        {iss: this.email, sub: this.email, aud: authURI, exp, iat},
-        additionalClaims);
+    const payload = Object.assign(defaultClaims, additionalClaims);
 
     // Sign the jwt and add it to the cache
     const signedJWT =

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -94,7 +94,7 @@ export class JWT extends OAuth2Client {
   /**
    * Obtains the metadata to be sent with the request.
    *
-   * @param {string} optUri the URI being authorized.
+   * @param optUri the URI being authorized.
    */
   protected async getRequestMetadataAsync(url?: string|null):
       Promise<RequestMetadataResponse> {
@@ -169,7 +169,6 @@ export class JWT extends OAuth2Client {
    * @private
    */
   async refreshToken(refreshToken?: string|null): Promise<GetTokenResponse> {
-    console.log('refreshing the token!');
     if (!this.gtoken) {
       this.gtoken = new GoogleToken({
         iss: this.email,
@@ -181,7 +180,6 @@ export class JWT extends OAuth2Client {
       });
     }
     const token = await this.gtoken.getToken();
-    console.log(`Token: ${token}`);
     const tokens = {
       access_token: token,
       token_type: 'Bearer',

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import {GoogleToken, TokenOptions} from 'gtoken';
+import {GoogleToken} from 'gtoken';
 import * as stream from 'stream';
-
 import {Credentials, JWTInput} from './credentials';
 import {JWTAccess} from './jwtaccess';
 import {GetTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';
@@ -29,6 +28,7 @@ export interface JWTOptions extends RefreshOptions {
   key?: string;
   scopes?: string|string[];
   subject?: string;
+  additionalClaims?: {};
 }
 
 export class JWT extends OAuth2Client {
@@ -39,6 +39,9 @@ export class JWT extends OAuth2Client {
   scope?: string;
   subject?: string;
   gtoken: GoogleToken;
+  additionalClaims?: {};
+
+  private access: JWTAccess;
 
   /**
    * JWT service account credentials.
@@ -68,6 +71,7 @@ export class JWT extends OAuth2Client {
     this.key = opts.key;
     this.scopes = opts.scopes;
     this.subject = opts.subject;
+    this.additionalClaims = opts.additionalClaims;
     this.credentials = {refresh_token: 'jwt-placeholder', expiry_date: 1};
   }
 
@@ -82,7 +86,8 @@ export class JWT extends OAuth2Client {
       keyFile: this.keyFile,
       key: this.key,
       scopes,
-      subject: this.subject
+      subject: this.subject,
+      additionalClaims: this.additionalClaims
     });
   }
 
@@ -93,11 +98,17 @@ export class JWT extends OAuth2Client {
    */
   protected async getRequestMetadataAsync(url?: string|null):
       Promise<RequestMetadataResponse> {
-    if (this.createScopedRequired() && url) {
-      // no scopes have been set, but a uri has been provided.  Use JWTAccess
-      // credentials.
-      const alt = new JWTAccess(this.email, this.key);
-      return alt.getRequestMetadata(url);
+    if (!this.apiKey && this.createScopedRequired() && url) {
+      if (this.additionalClaims && (this.additionalClaims as any).target_audience) {
+        const {tokens} = await this.refreshToken();
+        return {headers: {Authorization: `Bearer ${tokens.access_token}`}};
+      } else {
+        // no scopes have been set, but a uri has been provided. Use JWTAccess credentials.
+        if (!this.access) {
+          this.access = new JWTAccess(this.email, this.key);
+        }
+        return this.access.getRequestMetadata(url, this.additionalClaims);
+      }
     } else {
       return super.getRequestMetadataAsync(url);
     }
@@ -151,16 +162,27 @@ export class JWT extends OAuth2Client {
 
   /**
    * Refreshes the access token.
-   * @param {object=} ignored
+   * @param refreshToken ignored
    * @private
    */
   async refreshToken(refreshToken?: string|null): Promise<GetTokenResponse> {
-    const newGToken = this.createGToken();
-    const token = await newGToken.getToken();
+    console.log('refreshing the token!');
+    if (!this.gtoken) {
+      this.gtoken = new GoogleToken({
+        iss: this.email,
+        sub: this.subject,
+        scope: this.scopes,
+        keyFile: this.keyFile,
+        key: this.key,
+        additionalClaims: this.additionalClaims
+      });
+    }
+    const token = await this.gtoken.getToken();
+    console.log(`Token: ${token}`);
     const tokens = {
       access_token: token,
       token_type: 'Bearer',
-      expiry_date: newGToken.expiresAt
+      expiry_date: this.gtoken.expiresAt
     };
     return {res: null, tokens};
   }
@@ -238,23 +260,5 @@ export class JWT extends OAuth2Client {
       throw new Error('Must provide an API Key string.');
     }
     this.apiKey = apiKey;
-  }
-
-  /**
-   * Creates the gToken instance if it has not been created already.
-   * @param {function=} callback Callback.
-   * @private
-   */
-  private createGToken() {
-    if (!this.gtoken) {
-      this.gtoken = new GoogleToken({
-        iss: this.email,
-        sub: this.subject,
-        scope: this.scopes,
-        keyFile: this.keyFile,
-        key: this.key
-      } as TokenOptions);
-    }
-    return this.gtoken;
   }
 }

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -99,11 +99,14 @@ export class JWT extends OAuth2Client {
   protected async getRequestMetadataAsync(url?: string|null):
       Promise<RequestMetadataResponse> {
     if (!this.apiKey && this.createScopedRequired() && url) {
-      if (this.additionalClaims && (this.additionalClaims as any).target_audience) {
+      if (this.additionalClaims && (this.additionalClaims as {
+                                     target_audience: string
+                                   }).target_audience) {
         const {tokens} = await this.refreshToken();
         return {headers: {Authorization: `Bearer ${tokens.access_token}`}};
       } else {
-        // no scopes have been set, but a uri has been provided. Use JWTAccess credentials.
+        // no scopes have been set, but a uri has been provided. Use JWTAccess
+        // credentials.
         if (!this.access) {
           this.access = new JWTAccess(this.email, this.key);
         }

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -649,10 +649,9 @@ export class OAuth2Client extends AuthClient {
   }
 
   /**
-   * Provides a request implementation with OAuth 2.0 flow.
-   * If credentials have a refresh_token, in cases of HTTP
-   * 401 and 403 responses, it automatically asks for a new
-   * access token and replays the unsuccessful request.
+   * Provides a request implementation with OAuth 2.0 flow. If credentials have
+   * a refresh_token, in cases of HTTP 401 and 403 responses, it automatically
+   * asks for a new access token and replays the unsuccessful request.
    * @param {object} opts Request options.
    * @param {function} callback callback.
    * @return {Request} Request object
@@ -676,7 +675,7 @@ export class OAuth2Client extends AuthClient {
       Promise<AxiosResponse<T>> {
     let r2: AxiosResponse;
     try {
-      const r = await this.getRequestMetadataAsync(null);
+      const r = await this.getRequestMetadataAsync(opts.url);
       if (r.headers && r.headers.Authorization) {
         opts.headers = opts.headers || {};
         opts.headers.Authorization = r.headers.Authorization;

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -60,16 +60,11 @@ describe('.getRequestMetadata', () => {
     assert.strictEqual(testUri, payload.aud);
   });
 
-  it('should allow overriding with additionalClaims', () => {
+  it('should not allow overriding with additionalClaims', () => {
     const additionalClaims = {iss: 'not-the-email'};
-    const res = client.getRequestMetadata(testUri, additionalClaims);
-    assert.notStrictEqual(
-        null, res.headers, 'an creds object should be present');
-    const decoded = jws.decode(
-        (res.headers!.Authorization as string).replace('Bearer ', ''));
-    const payload = JSON.parse(decoded.payload);
-    assert.strictEqual('not-the-email', payload.iss);
-    assert.strictEqual(email, payload.sub);
+    assert.throws(() => {
+      client.getRequestMetadata(testUri, additionalClaims);
+    }, `The 'iss' property is not allowed when passing additionalClaims. This claim is included in the JWT by default.`);
   });
 
   it('should return a cached token on the second request', () => {


### PR DESCRIPTION
Adds support for additionalClaims to JWT, and an example of using it to work with the Identity Aware Proxy (IAP). Resolves #134  🤘