### PR TITLE
Update token endpoint + fix failing tests

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -27,7 +27,7 @@ export class Compute extends OAuth2Client {
    * Google Compute Engine metadata server token endpoint.
    */
   protected static readonly _GOOGLE_OAUTH2_TOKEN_URL =
-      'http://metadata.google.internal/computeMetadata/v1beta1/instance/service-accounts/default/token';
+      'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token';
 
   /**
    * Google Compute Engine service account credentials.

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -46,7 +46,7 @@ describe('Compute auth client', () => {
 
   it('should get an access token for the first request', done => {
     nock('http://metadata.google.internal')
-        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
+        .get('/computeMetadata/v1/instance/service-accounts/default/token')
         .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.request({url: 'http://foo'}, () => {
       assert.equal(compute.credentials.access_token, 'abc123');
@@ -56,7 +56,7 @@ describe('Compute auth client', () => {
 
   it('should refresh if access token has expired', (done) => {
     nock('http://metadata.google.internal')
-        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
+        .get('/computeMetadata/v1/instance/service-accounts/default/token')
         .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.credentials.access_token = 'initial-access-token';
     compute.credentials.expiry_date = (new Date()).getTime() - 10000;
@@ -70,8 +70,7 @@ describe('Compute auth client', () => {
          ' before expiration is set',
      (done) => {
        nock('http://metadata.google.internal')
-           .get(
-               '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+           .get('/computeMetadata/v1/instance/service-accounts/default/token')
            .reply(200, {access_token: 'abc123', expires_in: 10000});
        compute = new Compute({eagerRefreshThresholdMillis: 10000});
        compute.credentials.access_token = 'initial-access-token';
@@ -88,7 +87,7 @@ describe('Compute auth client', () => {
        const scope =
            nock('http://metadata.google.internal')
                .get(
-                   '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+                   '/computeMetadata/v1/instance/service-accounts/default/token')
                .reply(200, {access_token: 'abc123', expires_in: 10000});
        compute = new Compute({eagerRefreshThresholdMillis: 1000});
        compute.credentials.access_token = 'initial-access-token';
@@ -104,8 +103,7 @@ describe('Compute auth client', () => {
   it('should not refresh if access token has not expired', (done) => {
     const scope =
         nock('http://metadata.google.internal')
-            .get(
-                '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+            .get('/computeMetadata/v1/instance/service-accounts/default/token')
             .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.credentials.access_token = 'initial-access-token';
     compute.credentials.expiry_date = (new Date()).getTime() + 10 * 60 * 1000;
@@ -135,8 +133,7 @@ describe('Compute auth client', () => {
 
       nock('http://foo').get('/').twice().reply(403, 'a weird response body');
       nock('http://metadata.google.internal')
-          .get(
-              '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+          .get('/computeMetadata/v1/instance/service-accounts/default/token')
           .reply(403, 'a weird response body');
 
       compute.request({url: 'http://foo'}, (err, response) => {
@@ -182,8 +179,7 @@ describe('Compute auth client', () => {
     it('should return a helpful message on token refresh response.statusCode 403',
        (done) => {
          nock('http://metadata.google.internal')
-             .get(
-                 '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+             .get('/computeMetadata/v1/instance/service-accounts/default/token')
              .twice()
              .reply(403, 'a weird response body');
 
@@ -211,8 +207,7 @@ describe('Compute auth client', () => {
     it('should return a helpful message on token refresh response.statusCode 404',
        done => {
          nock('http://metadata.google.internal')
-             .get(
-                 '/computeMetadata/v1beta1/instance/service-accounts/default/token')
+             .get('/computeMetadata/v1/instance/service-accounts/default/token')
              .reply(404, 'a weird body');
 
          // Mock the credentials object with a null access token, to force

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1114,7 +1114,6 @@ describe('GoogleAuth', () => {
 describe('.getApplicationDefault', () => {
   it('should return a new credential the first time and a cached credential the second time',
      async () => {
-
        // Create a function which will set up a GoogleAuth instance to match
        // on an environment variable json file, but not on anything else.
        const setUpAuthForEnvironmentVariable = (creds: GoogleAuth) => {
@@ -1179,7 +1178,7 @@ describe('.getApplicationDefault', () => {
        assert.notEqual(cachedCredential, result3);
      });
 
-  it('should use environment variable when it is set', function(done) {
+  it('should use environment variable when it is set', (done) => {
 
     // We expect private.json to be the file that is used.
     const fileContents =

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1113,8 +1113,7 @@ describe('GoogleAuth', () => {
 
 describe('.getApplicationDefault', () => {
   it('should return a new credential the first time and a cached credential the second time',
-     async function() {
-       this.timeout(5000);
+     async () => {
 
        // Create a function which will set up a GoogleAuth instance to match
        // on an environment variable json file, but not on anything else.
@@ -1181,7 +1180,6 @@ describe('.getApplicationDefault', () => {
      });
 
   it('should use environment variable when it is set', function(done) {
-    this.timeout(5000);
 
     // We expect private.json to be the file that is used.
     const fileContents =

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1113,7 +1113,9 @@ describe('GoogleAuth', () => {
 
 describe('.getApplicationDefault', () => {
   it('should return a new credential the first time and a cached credential the second time',
-     async () => {
+     async function() {
+       this.timeout(5000);
+
        // Create a function which will set up a GoogleAuth instance to match
        // on an environment variable json file, but not on anything else.
        const setUpAuthForEnvironmentVariable = (creds: GoogleAuth) => {
@@ -1178,7 +1180,9 @@ describe('.getApplicationDefault', () => {
        assert.notEqual(cachedCredential, result3);
      });
 
-  it('should use environment variable when it is set', (done) => {
+  it('should use environment variable when it is set', function(done) {
+    this.timeout(5000);
+
     // We expect private.json to be the file that is used.
     const fileContents =
         fs.readFileSync('./test/fixtures/private.json', 'utf-8');

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1179,7 +1179,6 @@ describe('.getApplicationDefault', () => {
      });
 
   it('should use environment variable when it is set', (done) => {
-
     // We expect private.json to be the file that is used.
     const fileContents =
         fs.readFileSync('./test/fixtures/private.json', 'utf-8');


### PR DESCRIPTION
When I try to use this library in an `npm` Container Builder step (via the [Cloud Storage API](https://cloud.google.com/storage/docs)), I get the following error:
```
{ Error: 404 page not found
at new RequestError (/workspace/functions/autodeploy/node_modules/google-auth-library/lib/transporters.js:34:42)
at Request._callback (/workspace/functions/autodeploy/node_modules/google-auth-library/lib/transporters.js:108:23)
at Request.self.callback (/workspace/functions/autodeploy/node_modules/request/request.js:186:22)
at emitTwo (events.js:126:13)
at Request.emit (events.js:214:7)
at Request.<anonymous> (/workspace/functions/autodeploy/node_modules/request/request.js:1163:10)
at emitOne (events.js:116:13)
at Request.emit (events.js:211:7)
at IncomingMessage.<anonymous> (/workspace/functions/autodeploy/node_modules/request/request.js:1085:12)
at Object.onceWrapper (events.js:313:30)
at emitNone (events.js:111:20)
at IncomingMessage.emit (events.js:208:7)
at endReadableNT (_stream_readable.js:1056:12)
at _combinedTickCallback (internal/process/next_tick.js:138:11)
at process._tickCallback (internal/process/next_tick.js:180:9) code: 404 }
```

To (potentially) fix this, I've changed the `v1beta1` token endpoint URL to use `v1`, which in my tests returned a token (as opposed to 404ing like the `v1beta1` URL).

I've also updated the tests accordingly, and added timeouts to a few unrelated-but-flaky tests to ensure that they pass.