### PR TITLE
Revert "fix: Update GCE metadata token endpoint (#269)"

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -27,7 +27,7 @@ export class Compute extends OAuth2Client {
    * Google Compute Engine metadata server token endpoint.
    */
   protected static readonly _GOOGLE_OAUTH2_TOKEN_URL =
-      'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token';
+      'http://metadata.google.internal/computeMetadata/v1beta1/instance/service-accounts/default/token';
 
   /**
    * Google Compute Engine service account credentials.

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -46,7 +46,7 @@ describe('Compute auth client', () => {
 
   it('should get an access token for the first request', done => {
     nock('http://metadata.google.internal')
-        .get('/computeMetadata/v1/instance/service-accounts/default/token')
+        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
         .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.request({url: 'http://foo'}, () => {
       assert.equal(compute.credentials.access_token, 'abc123');
@@ -56,7 +56,7 @@ describe('Compute auth client', () => {
 
   it('should refresh if access token has expired', (done) => {
     nock('http://metadata.google.internal')
-        .get('/computeMetadata/v1/instance/service-accounts/default/token')
+        .get('/computeMetadata/v1beta1/instance/service-accounts/default/token')
         .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.credentials.access_token = 'initial-access-token';
     compute.credentials.expiry_date = (new Date()).getTime() - 10000;
@@ -70,7 +70,8 @@ describe('Compute auth client', () => {
          ' before expiration is set',
      (done) => {
        nock('http://metadata.google.internal')
-           .get('/computeMetadata/v1/instance/service-accounts/default/token')
+           .get(
+               '/computeMetadata/v1beta1/instance/service-accounts/default/token')
            .reply(200, {access_token: 'abc123', expires_in: 10000});
        compute = new Compute({eagerRefreshThresholdMillis: 10000});
        compute.credentials.access_token = 'initial-access-token';
@@ -87,7 +88,7 @@ describe('Compute auth client', () => {
        const scope =
            nock('http://metadata.google.internal')
                .get(
-                   '/computeMetadata/v1/instance/service-accounts/default/token')
+                   '/computeMetadata/v1beta1/instance/service-accounts/default/token')
                .reply(200, {access_token: 'abc123', expires_in: 10000});
        compute = new Compute({eagerRefreshThresholdMillis: 1000});
        compute.credentials.access_token = 'initial-access-token';
@@ -103,7 +104,8 @@ describe('Compute auth client', () => {
   it('should not refresh if access token has not expired', (done) => {
     const scope =
         nock('http://metadata.google.internal')
-            .get('/computeMetadata/v1/instance/service-accounts/default/token')
+            .get(
+                '/computeMetadata/v1beta1/instance/service-accounts/default/token')
             .reply(200, {access_token: 'abc123', expires_in: 10000});
     compute.credentials.access_token = 'initial-access-token';
     compute.credentials.expiry_date = (new Date()).getTime() + 10 * 60 * 1000;
@@ -133,7 +135,8 @@ describe('Compute auth client', () => {
 
       nock('http://foo').get('/').twice().reply(403, 'a weird response body');
       nock('http://metadata.google.internal')
-          .get('/computeMetadata/v1/instance/service-accounts/default/token')
+          .get(
+              '/computeMetadata/v1beta1/instance/service-accounts/default/token')
           .reply(403, 'a weird response body');
 
       compute.request({url: 'http://foo'}, (err, response) => {
@@ -179,7 +182,8 @@ describe('Compute auth client', () => {
     it('should return a helpful message on token refresh response.statusCode 403',
        (done) => {
          nock('http://metadata.google.internal')
-             .get('/computeMetadata/v1/instance/service-accounts/default/token')
+             .get(
+                 '/computeMetadata/v1beta1/instance/service-accounts/default/token')
              .twice()
              .reply(403, 'a weird response body');
 
@@ -207,7 +211,8 @@ describe('Compute auth client', () => {
     it('should return a helpful message on token refresh response.statusCode 404',
        done => {
          nock('http://metadata.google.internal')
-             .get('/computeMetadata/v1/instance/service-accounts/default/token')
+             .get(
+                 '/computeMetadata/v1beta1/instance/service-accounts/default/token')
              .reply(404, 'a weird body');
 
          // Mock the credentials object with a null access token, to force


### PR DESCRIPTION
This reverts commit 730d4b7d7de59b04862169fbc3a6feeab4d0debb. 

Turns out the GCF doesn't support the GCE metadata endpoint that includes /v1 👎 

Resolves #274 
Resolves #275 