### PR TITLE
test: flatten tests

### DIFF
--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -17,252 +17,228 @@
 import * as assert from 'assert';
 import {BASE_PATH, HOST_ADDRESS} from 'gcp-metadata';
 import * as nock from 'nock';
-
-import {Credentials} from '../src/auth/credentials';
 import {Compute} from '../src/index';
 
 nock.disableNetConnect();
 
 const tokenPath = `${BASE_PATH}/instance/service-accounts/default/token`;
 
-describe('Initial credentials', () => {
-  it('should create a dummy refresh token string', () => {
-    // It is important that the compute client is created with a refresh token
-    // value filled in, or else the rest of the logic will not work.
-    const compute = new Compute();
-    assert.equal('compute-placeholder', compute.credentials.refresh_token);
+// set up compute client.
+let compute: Compute;
+beforeEach(() => {
+  compute = new Compute();
+});
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+it('should create a dummy refresh token string', () => {
+  // It is important that the compute client is created with a refresh token
+  // value filled in, or else the rest of the logic will not work.
+  const compute = new Compute();
+  assert.equal('compute-placeholder', compute.credentials.refresh_token);
+});
+
+it('should get an access token for the first request', done => {
+  nock(HOST_ADDRESS).get(tokenPath).reply(200, {
+    access_token: 'abc123',
+    expires_in: 10000
+  });
+  compute.request({url: 'http://foo'}, () => {
+    assert.equal(compute.credentials.access_token, 'abc123');
+    done();
   });
 });
 
-describe('Compute auth client', () => {
-  afterEach(() => {
+it('should refresh if access token has expired', done => {
+  nock(HOST_ADDRESS).get(tokenPath).reply(200, {
+    access_token: 'abc123',
+    expires_in: 10000
+  });
+  compute.credentials.access_token = 'initial-access-token';
+  compute.credentials.expiry_date = (new Date()).getTime() - 10000;
+  compute.request({url: 'http://foo'}, () => {
+    assert.equal(compute.credentials.access_token, 'abc123');
+    done();
+  });
+});
+
+it('should refresh if access token will expired soon and time to refresh before expiration is set',
+   done => {
+     nock(HOST_ADDRESS).get(tokenPath).reply(200, {
+       access_token: 'abc123',
+       expires_in: 10000
+     });
+     compute = new Compute({eagerRefreshThresholdMillis: 10000});
+     compute.credentials.access_token = 'initial-access-token';
+     compute.credentials.expiry_date = (new Date()).getTime() + 5000;
+     compute.request({url: 'http://foo'}, () => {
+       assert.equal(compute.credentials.access_token, 'abc123');
+       done();
+     });
+   });
+
+it('should not refresh if access token will not expire soon and time to refresh before expiration is set',
+   done => {
+     const scope = nock(HOST_ADDRESS).get(tokenPath).reply(200, {
+       access_token: 'abc123',
+       expires_in: 10000
+     });
+     compute = new Compute({eagerRefreshThresholdMillis: 1000});
+     compute.credentials.access_token = 'initial-access-token';
+     compute.credentials.expiry_date = (new Date()).getTime() + 12000;
+     compute.request({url: 'http://foo'}, () => {
+       assert.equal(compute.credentials.access_token, 'initial-access-token');
+       assert.equal(false, scope.isDone());
+       nock.cleanAll();
+       done();
+     });
+   });
+
+it('should not refresh if access token has not expired', done => {
+  const scope = nock(HOST_ADDRESS).get(tokenPath).reply(200, {
+    access_token: 'abc123',
+    expires_in: 10000
+  });
+  compute.credentials.access_token = 'initial-access-token';
+  compute.credentials.expiry_date = (new Date()).getTime() + 10 * 60 * 1000;
+  compute.request({url: 'http://foo'}, () => {
+    assert.equal(compute.credentials.access_token, 'initial-access-token');
+    assert.equal(false, scope.isDone());
     nock.cleanAll();
+    done();
   });
+});
 
-  // set up compute client.
-  let compute: Compute;
-  beforeEach(() => {
-    compute = new Compute();
-  });
-
-  it('should get an access token for the first request', done => {
-    nock(HOST_ADDRESS).get(tokenPath).reply(200, {
-      access_token: 'abc123',
-      expires_in: 10000
-    });
-    compute.request({url: 'http://foo'}, () => {
-      assert.equal(compute.credentials.access_token, 'abc123');
-      done();
-    });
-  });
-
-  it('should refresh if access token has expired', (done) => {
-    nock(HOST_ADDRESS).get(tokenPath).reply(200, {
-      access_token: 'abc123',
-      expires_in: 10000
-    });
-    compute.credentials.access_token = 'initial-access-token';
-    compute.credentials.expiry_date = (new Date()).getTime() - 10000;
-    compute.request({url: 'http://foo'}, () => {
-      assert.equal(compute.credentials.access_token, 'abc123');
-      done();
-    });
-  });
-
-  it('should refresh if access token will expired soon and time to refresh' +
-         ' before expiration is set',
-     (done) => {
-       nock(HOST_ADDRESS).get(tokenPath).reply(200, {
-         access_token: 'abc123',
-         expires_in: 10000
-       });
-       compute = new Compute({eagerRefreshThresholdMillis: 10000});
-       compute.credentials.access_token = 'initial-access-token';
-       compute.credentials.expiry_date = (new Date()).getTime() + 5000;
-       compute.request({url: 'http://foo'}, () => {
-         assert.equal(compute.credentials.access_token, 'abc123');
-         done();
-       });
+it('should retry calls to the metadata service if there are network errors',
+   done => {
+     const scope = nock(HOST_ADDRESS)
+                       .get(tokenPath)
+                       .times(2)
+                       .replyWithError({code: 'ENOTFOUND'})
+                       .get(tokenPath)
+                       .reply(200, {access_token: 'abc123', expires_in: 10000});
+     compute.credentials.access_token = 'initial-access-token';
+     compute.credentials.expiry_date = (new Date()).getTime() - 10000;
+     compute.request({url: 'http://foo'}, e => {
+       assert.equal(compute.credentials.access_token, 'abc123');
+       scope.done();
+       done();
      });
+   });
 
-  it('should not refresh if access token will not expire soon and time to' +
-         ' refresh before expiration is set',
-     (done) => {
-       const scope = nock(HOST_ADDRESS).get(tokenPath).reply(200, {
-         access_token: 'abc123',
-         expires_in: 10000
-       });
-       compute = new Compute({eagerRefreshThresholdMillis: 1000});
-       compute.credentials.access_token = 'initial-access-token';
-       compute.credentials.expiry_date = (new Date()).getTime() + 12000;
-       compute.request({url: 'http://foo'}, () => {
-         assert.equal(compute.credentials.access_token, 'initial-access-token');
-         assert.equal(false, scope.isDone());
-         nock.cleanAll();
-         done();
-       });
+it('should retry calls to the metadata service if it returns non-200 errors',
+   done => {
+     const scope = nock(HOST_ADDRESS)
+                       .get(tokenPath)
+                       .times(2)
+                       .reply(500)
+                       .get(tokenPath)
+                       .reply(200, {access_token: 'abc123', expires_in: 10000});
+     compute.credentials.access_token = 'initial-access-token';
+     compute.credentials.expiry_date = (new Date()).getTime() - 10000;
+     compute.request({url: 'http://foo'}, e => {
+       assert.equal(compute.credentials.access_token, 'abc123');
+       scope.done();
+       done();
      });
+   });
 
-  it('should not refresh if access token has not expired', (done) => {
-    const scope = nock(HOST_ADDRESS).get(tokenPath).reply(200, {
-      access_token: 'abc123',
-      expires_in: 10000
-    });
-    compute.credentials.access_token = 'initial-access-token';
-    compute.credentials.expiry_date = (new Date()).getTime() + 10 * 60 * 1000;
-    compute.request({url: 'http://foo'}, () => {
-      assert.equal(compute.credentials.access_token, 'initial-access-token');
-      assert.equal(false, scope.isDone());
-      nock.cleanAll();
-      done();
-    });
+it('should return false for createScopedRequired', () => {
+  assert.equal(false, compute.createScopedRequired());
+});
+
+it('should return a helpful message on request response.statusCode 403', done => {
+  // Mock the credentials object.
+  compute.credentials = {
+    refresh_token: 'hello',
+    access_token: 'goodbye',
+    expiry_date: (new Date(9999, 1, 1)).getTime()
+  };
+
+  nock('http://foo').get('/').twice().reply(403, 'a weird response body');
+  nock(HOST_ADDRESS).get(tokenPath).reply(403, 'a weird response body');
+
+  compute.request({url: 'http://foo'}, (err, response) => {
+    assert(response);
+    assert.equal(403, response ? response.status : 0);
+    const expected =
+        'A Forbidden error was returned while attempting to retrieve an access ' +
+        'token for the Compute Engine built-in service account. This may be because the ' +
+        'Compute Engine instance does not have the correct permission scopes specified. ' +
+        'Could not refresh access token.';
+    assert.equal(expected, err ? err.message : null);
+    done();
   });
+});
 
-  it('should retry calls to the metadata service if there are network errors',
-     (done) => {
-       const scope =
-           nock(HOST_ADDRESS)
-               .get(tokenPath)
-               .times(2)
-               .replyWithError({code: 'ENOTFOUND'})
-               .get(tokenPath)
-               .reply(200, {access_token: 'abc123', expires_in: 10000});
-       compute.credentials.access_token = 'initial-access-token';
-       compute.credentials.expiry_date = (new Date()).getTime() - 10000;
-       compute.request({url: 'http://foo'}, e => {
-         assert.equal(compute.credentials.access_token, 'abc123');
-         scope.done();
-         done();
-       });
-     });
+it('should return a helpful message on request response.statusCode 404', done => {
+  // Mock the credentials object.
+  compute.credentials = {
+    refresh_token: 'hello',
+    access_token: 'goodbye',
+    expiry_date: (new Date(9999, 1, 1)).getTime()
+  };
 
-  it('should retry calls to the metadata service if it returns non-200 errors',
-     (done) => {
-       const scope =
-           nock(HOST_ADDRESS)
-               .get(tokenPath)
-               .times(2)
-               .reply(500)
-               .get(tokenPath)
-               .reply(200, {access_token: 'abc123', expires_in: 10000});
-       compute.credentials.access_token = 'initial-access-token';
-       compute.credentials.expiry_date = (new Date()).getTime() - 10000;
-       compute.request({url: 'http://foo'}, e => {
-         assert.equal(compute.credentials.access_token, 'abc123');
-         scope.done();
-         done();
-       });
-     });
+  // Mock the request method to return a 404.
+  nock('http://foo').get('/').twice().reply(404, 'a weird response body');
 
-  describe('.createScopedRequired', () => {
-    it('should return false', () => {
-      const c = new Compute();
-      assert.equal(false, c.createScopedRequired());
-    });
-  });
-
-  describe('._injectErrorMessage', () => {
-    it('should return a helpful message on request response.statusCode 403', done => {
-      // Mock the credentials object.
-      compute.credentials = {
-        refresh_token: 'hello',
-        access_token: 'goodbye',
-        expiry_date: (new Date(9999, 1, 1)).getTime()
-      };
-
-      nock('http://foo').get('/').twice().reply(403, 'a weird response body');
-      nock(HOST_ADDRESS).get(tokenPath).reply(403, 'a weird response body');
-
-      compute.request({url: 'http://foo'}, (err, response) => {
-        assert(response);
-        assert.equal(403, response ? response.status : 0);
-        const expected =
-            'A Forbidden error was returned while attempting to retrieve an access ' +
+  compute.request({url: 'http://foo'}, (err, response) => {
+    assert.equal(404, response ? response.status : 0);
+    assert.equal(
+        'A Not Found error was returned while attempting to retrieve an access' +
             'token for the Compute Engine built-in service account. This may be because the ' +
-            'Compute Engine instance does not have the correct permission scopes specified. ' +
-            'Could not refresh access token.';
-        assert.equal(expected, err ? err.message : null);
-        done();
-      });
-    });
+            'Compute Engine instance does not have any permission scopes specified. ' +
+            'a weird response body',
+        err ? err.message : null);
+    done();
+  });
+});
 
-    it('should return a helpful message on request response.statusCode 404',
-       (done) => {
-         // Mock the credentials object.
-         compute.credentials = {
-           refresh_token: 'hello',
-           access_token: 'goodbye',
-           expiry_date: (new Date(9999, 1, 1)).getTime()
-         };
+it('should return a helpful message on token refresh response.statusCode 403', done => {
+  nock(HOST_ADDRESS).get(tokenPath).twice().reply(403, 'a weird response body');
 
-         // Mock the request method to return a 404.
-         nock('http://foo')
-             .get('/')
-             .twice()
-             .reply(404, 'a weird response body');
+  // Mock the credentials object with a null access token, to force
+  // a refresh.
+  compute.credentials = {
+    refresh_token: 'hello',
+    access_token: undefined,
+    expiry_date: 1
+  };
 
-         compute.request({url: 'http://foo'}, (err, response) => {
-           assert.equal(404, response ? response.status : 0);
-           assert.equal(
-               'A Not Found error was returned while attempting to retrieve an access' +
-                   'token for the Compute Engine built-in service account. This may be because the ' +
-                   'Compute Engine instance does not have any permission scopes specified. ' +
-                   'a weird response body',
-               err ? err.message : null);
-           done();
-         });
-       });
+  compute.request({}, (err, response) => {
+    assert.equal(403, response ? response.status : null);
+    const expected =
+        'A Forbidden error was returned while attempting to retrieve an access ' +
+        'token for the Compute Engine built-in service account. This may be because the ' +
+        'Compute Engine instance does not have the correct permission scopes specified. ' +
+        'Could not refresh access token.';
+    assert.equal(expected, err ? err.message : null);
+    nock.cleanAll();
+    done();
+  });
+});
 
-    it('should return a helpful message on token refresh response.statusCode 403',
-       (done) => {
-         nock(HOST_ADDRESS)
-             .get(tokenPath)
-             .twice()
-             .reply(403, 'a weird response body');
+it('should return a helpful message on token refresh response.statusCode 404', done => {
+  nock(HOST_ADDRESS).get(tokenPath).reply(404, 'a weird body');
 
-         // Mock the credentials object with a null access token, to force
-         // a refresh.
-         compute.credentials = {
-           refresh_token: 'hello',
-           access_token: undefined,
-           expiry_date: 1
-         };
+  // Mock the credentials object with a null access token, to force
+  // a refresh.
+  compute.credentials = {
+    refresh_token: 'hello',
+    access_token: undefined,
+    expiry_date: 1
+  };
 
-         compute.request({}, (err, response) => {
-           assert.equal(403, response ? response.status : null);
-           const expected =
-               'A Forbidden error was returned while attempting to retrieve an access ' +
-               'token for the Compute Engine built-in service account. This may be because the ' +
-               'Compute Engine instance does not have the correct permission scopes specified. ' +
-               'Could not refresh access token.';
-           assert.equal(expected, err ? err.message : null);
-           nock.cleanAll();
-           done();
-         });
-       });
-
-    it('should return a helpful message on token refresh response.statusCode 404',
-       done => {
-         nock(HOST_ADDRESS).get(tokenPath).reply(404, 'a weird body');
-
-         // Mock the credentials object with a null access token, to force
-         // a refresh.
-         compute.credentials = {
-           refresh_token: 'hello',
-           access_token: undefined,
-           expiry_date: 1
-         } as Credentials;
-
-         compute.request({}, (err, response) => {
-           assert.equal(404, response ? response.status : null);
-           assert.equal(
-               'A Not Found error was returned while attempting to retrieve an access' +
-                   'token for the Compute Engine built-in service account. This may be because the ' +
-                   'Compute Engine instance does not have any permission scopes specified. Could not ' +
-                   'refresh access token.',
-               err ? err.message : null);
-           done();
-         });
-       });
+  compute.request({}, (err, response) => {
+    assert.equal(404, response ? response.status : null);
+    assert.equal(
+        'A Not Found error was returned while attempting to retrieve an access' +
+            'token for the Compute Engine built-in service account. This may be because the ' +
+            'Compute Engine instance does not have any permission scopes specified. Could not ' +
+            'refresh access token.',
+        err ? err.message : null);
+    done();
   });
 });

--- a/test/test.iam.ts
+++ b/test/test.iam.ts
@@ -15,29 +15,17 @@
  */
 
 import * as assert from 'assert';
+import {IAMAuth} from '../src/index';
 
-import {RequestMetadata} from '../src/auth/iam';
-import {GoogleAuth, IAMAuth} from '../src/index';
-
-describe('.getRequestMetadata', () => {
+it('passes the token and selector to the callback ', done => {
   const testSelector = 'a-test-selector';
   const testToken = 'a-test-token';
-  let client: IAMAuth;
-  beforeEach(() => {
-    client = new IAMAuth(testSelector, testToken);
-  });
-
-  it('passes the token and selector to the callback ', (done) => {
-    const expectRequestMetadata =
-        (err: Error|null, creds?: RequestMetadata) => {
-          assert.strictEqual(err, null, 'no error was expected: got\n' + err);
-          assert.notStrictEqual(creds, null, 'metadata should be present');
-          assert.strictEqual(
-              creds!['x-goog-iam-authority-selector'], testSelector);
-          assert.strictEqual(
-              creds!['x-goog-iam-authorization-token'], testToken);
-          done();
-        };
-    client.getRequestMetadata(null, expectRequestMetadata);
+  const client = new IAMAuth(testSelector, testToken);
+  client.getRequestMetadata(null, (err, creds) => {
+    assert.strictEqual(err, null, 'no error was expected: got\n' + err);
+    assert.notStrictEqual(creds, null, 'metadata should be present');
+    assert.strictEqual(creds!['x-goog-iam-authority-selector'], testSelector);
+    assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
+    done();
   });
 });

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -17,14 +17,12 @@ import * as assert from 'assert';
 
 import {DefaultTransporter, GoogleAuth} from '../src/';
 
-describe('module', () => {
-  it('should publicly export GoogleAuth', () => {
-    const cjs = require('../src/');
-    assert.strictEqual(cjs.GoogleAuth, GoogleAuth);
-  });
+it('should publicly export GoogleAuth', () => {
+  const cjs = require('../src/');
+  assert.strictEqual(cjs.GoogleAuth, GoogleAuth);
+});
 
-  it('should publicly export DefaultTransporter', () => {
-    const cjs = require('../src');
-    assert.strictEqual(cjs.DefaultTransporter, DefaultTransporter);
-  });
+it('should publicly export DefaultTransporter', () => {
+  const cjs = require('../src');
+  assert.strictEqual(cjs.DefaultTransporter, DefaultTransporter);
 });

--- a/test/test.kitchen.ts
+++ b/test/test.kitchen.ts
@@ -27,8 +27,8 @@ const stagingDir = tmp.dirSync({keep, unsafeCleanup: true});
 const stagingPath = stagingDir.name;
 const pkg = require('../../package.json');
 
-const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
-    Promise<void> => {
+const spawnp =
+    (command: string, args: string[], options: cp.SpawnOptions = {}) => {
       return new Promise((resolve, reject) => {
         cp.spawn(command, args, Object.assign(options, {stdio: 'inherit'}))
             .on('close',
@@ -50,17 +50,14 @@ const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
  * Create a staging directory with temp fixtures used
  * to test on a fresh application.
  */
-
-describe('kitchen sink', async () => {
-  it('should be able to use the d.ts', async () => {
-    console.log(`${__filename} staging area: ${stagingPath}`);
-    await spawnp('npm', ['pack']);
-    const tarball = `${pkg.name}-${pkg.version}.tgz`;
-    await rename(tarball, `${stagingPath}/google-auth-library.tgz`);
-    await ncpp('test/fixtures/kitchen', `${stagingPath}/`);
-    await spawnp('npm', ['install'], {cwd: `${stagingPath}/`});
-  }).timeout(40000);
-});
+it('should be able to use the d.ts', async () => {
+  console.log(`${__filename} staging area: ${stagingPath}`);
+  await spawnp('npm', ['pack']);
+  const tarball = `${pkg.name}-${pkg.version}.tgz`;
+  await rename(tarball, `${stagingPath}/google-auth-library.tgz`);
+  await ncpp('test/fixtures/kitchen', `${stagingPath}/`);
+  await spawnp('npm', ['install'], {cwd: `${stagingPath}/`});
+}).timeout(40000);
 
 /**
  * CLEAN UP - remove the staging directory when done.

--- a/test/test.loginticket.ts
+++ b/test/test.loginticket.ts
@@ -17,21 +17,19 @@
 import * as assert from 'assert';
 import {LoginTicket} from '../src/auth/loginticket';
 
-describe('LoginTicket', () => {
-  it('should return null userId even if no payload', () => {
-    const ticket = new LoginTicket();
-    assert.equal(ticket.getUserId(), null);
-  });
+it('should return null userId even if no payload', () => {
+  const ticket = new LoginTicket();
+  assert.equal(ticket.getUserId(), null);
+});
 
-  it('should return envelope', () => {
-    const ticket = new LoginTicket('myenvelope');
-    assert.equal(ticket.getEnvelope(), 'myenvelope');
-  });
+it('should return envelope', () => {
+  const ticket = new LoginTicket('myenvelope');
+  assert.equal(ticket.getEnvelope(), 'myenvelope');
+});
 
-  it('should return attributes from getAttributes', () => {
-    const payload =
-        {aud: 'aud', sub: 'sub', iss: 'iss', iat: 1514162443, exp: 1514166043};
-    const ticket = new LoginTicket('myenvelope', payload);
-    assert.deepEqual(ticket.getAttributes(), {envelope: 'myenvelope', payload});
-  });
+it('should return attributes from getAttributes', () => {
+  const payload =
+      {aud: 'aud', sub: 'sub', iss: 'iss', iat: 1514162443, exp: 1514166043};
+  const ticket = new LoginTicket('myenvelope', payload);
+  assert.deepEqual(ticket.getAttributes(), {envelope: 'myenvelope', payload});
 });

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -15,1222 +15,928 @@
  */
 
 import * as assert from 'assert';
-import {AxiosError, AxiosRequestConfig} from 'axios';
+import {AxiosError} from 'axios';
 import * as crypto from 'crypto';
-import {randomBytes} from 'crypto';
 import * as fs from 'fs';
 import * as nock from 'nock';
 import * as path from 'path';
-import * as pify from 'pify';
 import * as qs from 'querystring';
 import * as url from 'url';
 
+import {CodeChallengeMethod, GoogleAuth, OAuth2Client} from '../src';
 import {LoginTicket} from '../src/auth/loginticket';
-import {CodeChallengeMethod, GoogleAuth, OAuth2Client} from '../src/index';
 
 nock.disableNetConnect();
 
-describe('OAuth2 client', () => {
-  const CLIENT_ID = 'CLIENT_ID';
-  const CLIENT_SECRET = 'CLIENT_SECRET';
-  const REDIRECT_URI = 'REDIRECT';
-  const ACCESS_TYPE = 'offline';
-  const SCOPE = 'scopex';
-  const SCOPE_ARRAY = ['scopex', 'scopey'];
+const CLIENT_ID = 'CLIENT_ID';
+const CLIENT_SECRET = 'CLIENT_SECRET';
+const REDIRECT_URI = 'REDIRECT';
+const ACCESS_TYPE = 'offline';
+const SCOPE = 'scopex';
+const SCOPE_ARRAY = ['scopex', 'scopey'];
+const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
+const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
+const certsBaseUrl = 'https://www.googleapis.com';
+const certsPath = '/oauth2/v1/certs';
+const certsResPath =
+    path.join(__dirname, '../../test/fixtures/oauthcerts.json');
 
-  it('should generate a valid consent page url', (done) => {
-    const opts = {
-      access_type: ACCESS_TYPE,
-      scope: SCOPE,
-      response_type: 'code token'
-    };
+let client: OAuth2Client;
+beforeEach(() => {
+  client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+});
 
-    const oauth2client = new OAuth2Client({
-      clientId: CLIENT_ID,
-      clientSecret: CLIENT_SECRET,
-      redirectUri: REDIRECT_URI
-    });
+afterEach(() => {
+  nock.cleanAll();
+});
 
-    const generated = oauth2client.generateAuthUrl(opts);
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.response_type, 'code token');
-    assert.equal(query.access_type, ACCESS_TYPE);
-    assert.equal(query.scope, SCOPE);
-    assert.equal(query.client_id, CLIENT_ID);
-    assert.equal(query.redirect_uri, REDIRECT_URI);
-    done();
+it('should generate a valid consent page url', done => {
+  const opts = {
+    access_type: ACCESS_TYPE,
+    scope: SCOPE,
+    response_type: 'code token'
+  };
+
+  const oauth2client = new OAuth2Client({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUri: REDIRECT_URI
   });
 
-  it('should throw an error if generateAuthUrl is called with invalid parameters',
-     () => {
-       const opts = {
-         access_type: ACCESS_TYPE,
-         scope: SCOPE,
-         code_challenge_method: CodeChallengeMethod.S256
-       };
+  const generated = oauth2client.generateAuthUrl(opts);
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.response_type, 'code token');
+  assert.equal(query.access_type, ACCESS_TYPE);
+  assert.equal(query.scope, SCOPE);
+  assert.equal(query.client_id, CLIENT_ID);
+  assert.equal(query.redirect_uri, REDIRECT_URI);
+  done();
+});
 
-       const oauth2client =
-           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       try {
-         const generated = oauth2client.generateAuthUrl(opts);
-         assert.fail('Expected to throw');
-       } catch (e) {
-         assert.equal(
-             e.message,
-             'If a code_challenge_method is provided, code_challenge must be included.');
-       }
-     });
+it('should throw an error if generateAuthUrl is called with invalid parameters',
+   () => {
+     const opts = {
+       access_type: ACCESS_TYPE,
+       scope: SCOPE,
+       code_challenge_method: CodeChallengeMethod.S256
+     };
+     try {
+       const generated = client.generateAuthUrl(opts);
+       assert.fail('Expected to throw');
+     } catch (e) {
+       assert.equal(
+           e.message,
+           'If a code_challenge_method is provided, code_challenge must be included.');
+     }
+   });
 
-  it('should generate a valid code verifier and resulting challenge', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const codes = oauth2client.generateCodeVerifier();
+it('should generate a valid code verifier and resulting challenge', () => {
+  const codes = client.generateCodeVerifier();
+  // ensure the code_verifier matches all requirements
+  assert.equal(codes.codeVerifier.length, 128);
+  const match = codes.codeVerifier.match(/[a-zA-Z0-9\-\.~_]*/);
+  assert(match);
+  if (!match) return;
+  assert(match.length > 0 && match[0] === codes.codeVerifier);
+});
 
-    // ensure the code_verifier matches all requirements
-    assert.equal(codes.codeVerifier.length, 128);
-    const match = codes.codeVerifier.match(/[a-zA-Z0-9\-\.~_]*/);
-    assert(match);
-    if (!match) return;
-    assert(match.length > 0 && match[0] === codes.codeVerifier);
+it('should include code challenge and method in the url', () => {
+  const codes = client.generateCodeVerifier();
+  const authUrl = client.generateAuthUrl({
+    code_challenge: codes.codeChallenge,
+    code_challenge_method: CodeChallengeMethod.S256
   });
-
-  it('should include code challenge and method in the url', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const codes = oauth2client.generateCodeVerifier();
-    const authUrl = oauth2client.generateAuthUrl({
-      code_challenge: codes.codeChallenge,
-      code_challenge_method: CodeChallengeMethod.S256
-    });
-    const parsed = url.parse(authUrl);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const props = qs.parse(parsed.query);
-    assert.equal(props.code_challenge, codes.codeChallenge);
-    assert.equal(props.code_challenge_method, CodeChallengeMethod.S256);
-  });
-
-  it('should verifyIdToken properly', async () => {
-    const client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const fakeCerts = {a: 'a', b: 'b'};
-    const idToken = 'idToken';
-    const audience = 'fakeAudience';
-    const maxExpiry = 5;
-    const payload =
-        {aud: 'aud', sub: 'sub', iss: 'iss', iat: 1514162443, exp: 1514166043};
-    nock('https://www.googleapis.com')
-        .get('/oauth2/v1/certs')
-        .reply(200, fakeCerts);
-    client.verifySignedJwtWithCerts =
-        (jwt: string, certs: {}, requiredAudience: string|string[],
-         issuers?: string[], theMaxExpiry?: number) => {
-          assert.equal(jwt, idToken);
-          assert.equal(JSON.stringify(certs), JSON.stringify(fakeCerts));
-          assert.equal(requiredAudience, audience);
-          assert.equal(theMaxExpiry, maxExpiry);
-          return new LoginTicket('c', payload);
-        };
-    const result = await client.verifyIdToken({idToken, audience, maxExpiry});
-    assert.notEqual(result, null);
-    if (result) {
-      assert.equal(result.getEnvelope(), 'c');
-      assert.equal(result.getPayload(), payload);
-    }
-  });
-
-  it('should provide a reasonable error in verifyIdToken with wrong parameters',
-     async () => {
-       const client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       const fakeCerts = {a: 'a', b: 'b'};
-       const idToken = 'idToken';
-       const audience = 'fakeAudience';
-       const payload = {
-         aud: 'aud',
-         sub: 'sub',
-         iss: 'iss',
-         iat: 1514162443,
-         exp: 1514166043
-       };
-       nock('https://www.googleapis.com')
-           .get('/oauth2/v1/certs')
-           .reply(200, fakeCerts);
-       client.verifySignedJwtWithCerts =
-           (jwt: string, certs: {}, requiredAudience: string|string[],
-            issuers?: string[], theMaxExpiry?: number) => {
-             assert.equal(jwt, idToken);
-             assert.equal(JSON.stringify(certs), JSON.stringify(fakeCerts));
-             assert.equal(requiredAudience, audience);
-             return new LoginTicket('c', payload);
-           };
-       try {
-         // tslint:disable-next-line no-any
-         await (client as any).verifyIdToken(idToken, audience);
-         throw new Error('Expected to throw');
-       } catch (e) {
-         assert.equal(
-             e.message,
-             'This method accepts an options object as the first parameter, which includes the idToken, audience, and maxExpiry.');
-       }
-     });
-
-  it('should allow scopes to be specified as array', (done) => {
-    const opts = {
-      access_type: ACCESS_TYPE,
-      scope: SCOPE_ARRAY,
-      response_type: 'code token'
-    };
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const generated = oauth2client.generateAuthUrl(opts);
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.scope, SCOPE_ARRAY.join(' '));
-    done();
-  });
-
-  it('should set response_type param to code if none is given while' +
-         'generating the consent page url',
-     (done) => {
-       const oauth2client =
-           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       const generated = oauth2client.generateAuthUrl();
-       const parsed = url.parse(generated);
-       if (typeof parsed.query !== 'string') {
-         throw new Error('Unable to parse querystring');
-       }
-       const query = qs.parse(parsed.query);
-       assert.equal(query.response_type, 'code');
-       done();
-     });
-
-  // jason: keep
-  /*
-  it('should return err no access or refresh token is set before making a
-  request', (done) => { const auth = new GoogleAuth(); const oauth2client = new
-  googleapis.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI); new
-  googleapis.GoogleApis() .urlshortener('v1').url.get({ shortUrl: '123', auth:
-  oauth2client }, function(err, result) { assert.equal(err.message, 'No access
-  or refresh token is set.'); assert.equal(result, null); done();
-      });
-  });
-
-  it('should not throw any exceptions if only refresh token is set', () => {
-    const oauth2client = new googleapis.OAuth2Client(CLIENT_ID, CLIENT_SECRET,
-  REDIRECT_URI); oauth2client.credentials = { refresh_token: 'refresh_token' };
-    assert.doesNotThrow(() => {
-      const google = new googleapis.GoogleApis();
-      const options = { auth: oauth2client, shortUrl: '...' };
-      google.urlshortener('v1').url.get(options, noop);
-    });
-  });
-
-  it('should set access token type to Bearer if none is set', (done) => {
-    const oauth2client = new googleapis.OAuth2Client(CLIENT_ID, CLIENT_SECRET,
-  REDIRECT_URI); oauth2client.credentials = { access_token: 'foo',
-  refresh_token: '' };
-
-    const scope =
-  nock('https://www.googleapis.com').get('/urlshortener/v1/url/history').reply(200);
-
-    const google = new googleapis.GoogleApis();
-    const urlshortener = google.urlshortener('v1');
-    urlshortener.url.list({ auth: oauth2client }, function(err) {
-      assert.equal(oauth2client.credentials.token_type, 'Bearer');
-      scope.done();
-      done(err);
-    });
-  });
-*/
-
-  it('should verify a valid certificate against a jwt', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const login = oauth2client.verifySignedJwtWithCerts(
-        data, {keyid: publicKey}, 'testaudience');
-
-    assert.equal(login.getUserId(), '123456789');
-    done();
-  });
-
-  it('should fail due to invalid audience', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"wrongaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Wrong recipient/);
-    done();
-  });
-
-  it('should fail due to invalid array of audiences', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"wrongaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const validAudiences = ['testaudience', 'extra-audience'];
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, validAudiences);
-    }, /Wrong recipient/);
-    done();
-  });
-
-  it('should fail due to invalid signature', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":1393241597,' +
-        '"exp":1393245497' +
-        '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    // Originally: data += '.'+signature;
-    data += signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Wrong number of segments/);
-
-    done();
-  });
-
-  it('should fail due to invalid envelope', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid"' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Can\'t parse token envelope/);
-
-    done();
-  });
-
-  it('should fail due to invalid payload', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer"' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Can\'t parse token payload/);
-
-    done();
-  });
-
-  it('should fail due to invalid signature', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    const data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64') + '.' +
-        'broken-signature';
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Invalid token signature/);
-
-    done();
-  });
-
-  it('should fail due to no expiration date', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const now = new Date().getTime() / 1000;
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /No expiration time/);
-
-    done();
-  });
-
-  it('should fail due to no issue time', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = new Date().getTime() / 1000;
-    const expiry = now + (maxLifetimeSecs / 2);
-
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /No issue time/);
-
-    done();
-  });
-
-  it('should fail due to certificate with expiration date in future',
-     (done) => {
-       const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-       const privateKey =
-           fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-       const maxLifetimeSecs = 86400;
-       const now = new Date().getTime() / 1000;
-       const expiry = now + (2 * maxLifetimeSecs);
-       const idToken = '{' +
-           '"iss":"testissuer",' +
-           '"aud":"testaudience",' +
-           '"azp":"testauthorisedparty",' +
-           '"email_verified":"true",' +
-           '"id":"123456789",' +
-           '"sub":"123456789",' +
-           '"email":"test@test.com",' +
-           '"iat":' + now + ',' +
-           '"exp":' + expiry + '}';
-       const envelope = '{' +
-           '"kid":"keyid",' +
-           '"alg":"RS256"' +
-           '}';
-
-       let data = new Buffer(envelope).toString('base64') + '.' +
-           new Buffer(idToken).toString('base64');
-
-       const signer = crypto.createSign('sha256');
-       signer.update(data);
-       const signature = signer.sign(privateKey, 'base64');
-
-       data += '.' + signature;
-
-       const oauth2client =
-           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       assert.throws(() => {
-         oauth2client.verifySignedJwtWithCerts(
-             data, {keyid: publicKey}, 'testaudience');
-       }, /Expiration time too far in future/);
-
-       done();
-     });
-
-  it('should pass due to expiration date in future with adjusted max expiry',
-     (done) => {
-       const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-       const privateKey =
-           fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-       const maxLifetimeSecs = 86400;
-       const now = new Date().getTime() / 1000;
-       const expiry = now + (2 * maxLifetimeSecs);
-       const maxExpiry = (3 * maxLifetimeSecs);
-       const idToken = '{' +
-           '"iss":"testissuer",' +
-           '"aud":"testaudience",' +
-           '"azp":"testauthorisedparty",' +
-           '"email_verified":"true",' +
-           '"id":"123456789",' +
-           '"sub":"123456789",' +
-           '"email":"test@test.com",' +
-           '"iat":' + now + ',' +
-           '"exp":' + expiry + '}';
-       const envelope = '{' +
-           '"kid":"keyid",' +
-           '"alg":"RS256"' +
-           '}';
-
-       let data = new Buffer(envelope).toString('base64') + '.' +
-           new Buffer(idToken).toString('base64');
-
-       const signer = crypto.createSign('sha256');
-       signer.update(data);
-       const signature = signer.sign(privateKey, 'base64');
-
-       data += '.' + signature;
-
-       const oauth2client =
-           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       oauth2client.verifySignedJwtWithCerts(
-           data, {keyid: publicKey}, 'testaudience', ['testissuer'], maxExpiry);
-
-       done();
-     });
-
-  it('should fail due to token being used to early', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const clockSkews = 300;
-    const now = (new Date().getTime() / 1000);
-    const expiry = now + (maxLifetimeSecs / 2);
-    const issueTime = now + (clockSkews * 2);
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + issueTime + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Token used too early/);
-
-    done();
-  });
-
-  it('should fail due to token being used to late', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const clockSkews = 300;
-    const now = (new Date().getTime() / 1000);
-    const expiry = now - (maxLifetimeSecs / 2);
-    const issueTime = now - (clockSkews * 2);
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + issueTime + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience');
-    }, /Token used too late/);
-
-    done();
-  });
-
-  it('should fail due to invalid issuer', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = (new Date().getTime() / 1000);
-    const expiry = now + (maxLifetimeSecs / 2);
-    const idToken = '{' +
-        '"iss":"invalidissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    assert.throws(() => {
-      oauth2client.verifySignedJwtWithCerts(
-          data, {keyid: publicKey}, 'testaudience', ['testissuer']);
-    }, /Invalid issuer/);
-
-    done();
-  });
-
-  it('should pass due to valid issuer', (done) => {
-    const publicKey = fs.readFileSync('./test/fixtures/public.pem', 'utf-8');
-    const privateKey = fs.readFileSync('./test/fixtures/private.pem', 'utf-8');
-
-    const maxLifetimeSecs = 86400;
-    const now = (new Date().getTime() / 1000);
-    const expiry = now + (maxLifetimeSecs / 2);
-    const idToken = '{' +
-        '"iss":"testissuer",' +
-        '"aud":"testaudience",' +
-        '"azp":"testauthorisedparty",' +
-        '"email_verified":"true",' +
-        '"id":"123456789",' +
-        '"sub":"123456789",' +
-        '"email":"test@test.com",' +
-        '"iat":' + now + ',' +
-        '"exp":' + expiry + '}';
-    const envelope = '{' +
-        '"kid":"keyid",' +
-        '"alg":"RS256"' +
-        '}';
-
-    let data = new Buffer(envelope).toString('base64') + '.' +
-        new Buffer(idToken).toString('base64');
-
-    const signer = crypto.createSign('sha256');
-    signer.update(data);
-    const signature = signer.sign(privateKey, 'base64');
-
-    data += '.' + signature;
-
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.verifySignedJwtWithCerts(
+  const parsed = url.parse(authUrl);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const props = qs.parse(parsed.query);
+  assert.equal(props.code_challenge, codes.codeChallenge);
+  assert.equal(props.code_challenge_method, CodeChallengeMethod.S256);
+});
+
+it('should verifyIdToken properly', async () => {
+  const fakeCerts = {a: 'a', b: 'b'};
+  const idToken = 'idToken';
+  const audience = 'fakeAudience';
+  const maxExpiry = 5;
+  const payload =
+      {aud: 'aud', sub: 'sub', iss: 'iss', iat: 1514162443, exp: 1514166043};
+  nock('https://www.googleapis.com')
+      .get('/oauth2/v1/certs')
+      .reply(200, fakeCerts);
+  client.verifySignedJwtWithCerts =
+      (jwt: string, certs: {}, requiredAudience: string|string[],
+       issuers?: string[], theMaxExpiry?: number) => {
+        assert.equal(jwt, idToken);
+        assert.equal(JSON.stringify(certs), JSON.stringify(fakeCerts));
+        assert.equal(requiredAudience, audience);
+        assert.equal(theMaxExpiry, maxExpiry);
+        return new LoginTicket('c', payload);
+      };
+  const result = await client.verifyIdToken({idToken, audience, maxExpiry});
+  assert.notEqual(result, null);
+  if (result) {
+    assert.equal(result.getEnvelope(), 'c');
+    assert.equal(result.getPayload(), payload);
+  }
+});
+
+it('should provide a reasonable error in verifyIdToken with wrong parameters',
+   async () => {
+     const fakeCerts = {a: 'a', b: 'b'};
+     const idToken = 'idToken';
+     const audience = 'fakeAudience';
+     const payload =
+         {aud: 'aud', sub: 'sub', iss: 'iss', iat: 1514162443, exp: 1514166043};
+     nock('https://www.googleapis.com')
+         .get('/oauth2/v1/certs')
+         .reply(200, fakeCerts);
+     client.verifySignedJwtWithCerts =
+         (jwt: string, certs: {}, requiredAudience: string|string[],
+          issuers?: string[], theMaxExpiry?: number) => {
+           assert.equal(jwt, idToken);
+           assert.equal(JSON.stringify(certs), JSON.stringify(fakeCerts));
+           assert.equal(requiredAudience, audience);
+           return new LoginTicket('c', payload);
+         };
+     try {
+       // tslint:disable-next-line no-any
+       await (client as any).verifyIdToken(idToken, audience);
+       throw new Error('Expected to throw');
+     } catch (e) {
+       assert.equal(
+           e.message,
+           'This method accepts an options object as the first parameter, which includes the idToken, audience, and maxExpiry.');
+     }
+   });
+
+it('should allow scopes to be specified as array', () => {
+  const opts = {
+    access_type: ACCESS_TYPE,
+    scope: SCOPE_ARRAY,
+    response_type: 'code token'
+  };
+  const generated = client.generateAuthUrl(opts);
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.scope, SCOPE_ARRAY.join(' '));
+});
+
+it('should set response_type param to code if none is given while generating the consent page url',
+   () => {
+     const generated = client.generateAuthUrl();
+     const parsed = url.parse(generated);
+     if (typeof parsed.query !== 'string') {
+       throw new Error('Unable to parse querystring');
+     }
+     const query = qs.parse(parsed.query);
+     assert.equal(query.response_type, 'code');
+   });
+
+it('should verify a valid certificate against a jwt', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = JSON.stringify({kid: 'keyid', alg: 'RS256'});
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  const login =
+      client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  assert.equal(login.getUserId(), '123456789');
+});
+
+it('should fail due to invalid audience', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"wrongaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Wrong recipient/);
+});
+
+it('should fail due to invalid array of audiences', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"wrongaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  const validAudiences = ['testaudience', 'extra-audience'];
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, validAudiences);
+  }, /Wrong recipient/);
+});
+
+it('should fail due to invalid signature', () => {
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":1393241597,' +
+      '"exp":1393245497' +
+      '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  // Originally: data += '.'+signature;
+  data += signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Wrong number of segments/);
+});
+
+it('should fail due to invalid envelope', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid"' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Can\'t parse token envelope/);
+});
+
+it('should fail due to invalid payload', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer"' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Can\'t parse token payload/);
+});
+
+it('should fail due to invalid signature', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  const data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64') + '.' +
+      'broken-signature';
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Invalid token signature/);
+});
+
+it('should fail due to no expiration date', () => {
+  const now = new Date().getTime() / 1000;
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /No expiration time/);
+});
+
+it('should fail due to no issue time', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /No issue time/);
+});
+
+it('should fail due to certificate with expiration date in future', () => {
+  const maxLifetimeSecs = 86400;
+  const now = new Date().getTime() / 1000;
+  const expiry = now + (2 * maxLifetimeSecs);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Expiration time too far in future/);
+});
+
+it('should pass due to expiration date in future with adjusted max expiry',
+   () => {
+     const maxLifetimeSecs = 86400;
+     const now = new Date().getTime() / 1000;
+     const expiry = now + (2 * maxLifetimeSecs);
+     const maxExpiry = (3 * maxLifetimeSecs);
+     const idToken = '{' +
+         '"iss":"testissuer",' +
+         '"aud":"testaudience",' +
+         '"azp":"testauthorisedparty",' +
+         '"email_verified":"true",' +
+         '"id":"123456789",' +
+         '"sub":"123456789",' +
+         '"email":"test@test.com",' +
+         '"iat":' + now + ',' +
+         '"exp":' + expiry + '}';
+     const envelope = '{' +
+         '"kid":"keyid",' +
+         '"alg":"RS256"' +
+         '}';
+     let data = new Buffer(envelope).toString('base64') + '.' +
+         new Buffer(idToken).toString('base64');
+     const signer = crypto.createSign('sha256');
+     signer.update(data);
+     const signature = signer.sign(privateKey, 'base64');
+     data += '.' + signature;
+     client.verifySignedJwtWithCerts(
+         data, {keyid: publicKey}, 'testaudience', ['testissuer'], maxExpiry);
+   });
+
+it('should fail due to token being used to early', () => {
+  const maxLifetimeSecs = 86400;
+  const clockSkews = 300;
+  const now = (new Date().getTime() / 1000);
+  const expiry = now + (maxLifetimeSecs / 2);
+  const issueTime = now + (clockSkews * 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + issueTime + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Token used too early/);
+});
+
+it('should fail due to token being used to late', () => {
+  const maxLifetimeSecs = 86400;
+  const clockSkews = 300;
+  const now = (new Date().getTime() / 1000);
+  const expiry = now - (maxLifetimeSecs / 2);
+  const issueTime = now - (clockSkews * 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + issueTime + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(data, {keyid: publicKey}, 'testaudience');
+  }, /Token used too late/);
+});
+
+it('should fail due to invalid issuer', () => {
+  const maxLifetimeSecs = 86400;
+  const now = (new Date().getTime() / 1000);
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"invalidissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  assert.throws(() => {
+    client.verifySignedJwtWithCerts(
         data, {keyid: publicKey}, 'testaudience', ['testissuer']);
+  }, /Invalid issuer/);
+});
 
+it('should pass due to valid issuer', () => {
+  const maxLifetimeSecs = 86400;
+  const now = (new Date().getTime() / 1000);
+  const expiry = now + (maxLifetimeSecs / 2);
+  const idToken = '{' +
+      '"iss":"testissuer",' +
+      '"aud":"testaudience",' +
+      '"azp":"testauthorisedparty",' +
+      '"email_verified":"true",' +
+      '"id":"123456789",' +
+      '"sub":"123456789",' +
+      '"email":"test@test.com",' +
+      '"iat":' + now + ',' +
+      '"exp":' + expiry + '}';
+  const envelope = '{' +
+      '"kid":"keyid",' +
+      '"alg":"RS256"' +
+      '}';
+  let data = new Buffer(envelope).toString('base64') + '.' +
+      new Buffer(idToken).toString('base64');
+  const signer = crypto.createSign('sha256');
+  signer.update(data);
+  const signature = signer.sign(privateKey, 'base64');
+  data += '.' + signature;
+  client.verifySignedJwtWithCerts(
+      data, {keyid: publicKey}, 'testaudience', ['testissuer']);
+});
+
+it('should be able to retrieve a list of Google certificates', (done) => {
+  const scope =
+      nock(certsBaseUrl).get(certsPath).replyWithFile(200, certsResPath);
+  client.getFederatedSignonCerts((err, certs) => {
+    assert.equal(err, null);
+    assert.equal(Object.keys(certs).length, 2);
+    assert.notEqual(certs.a15eea964ab9cce480e5ef4f47cb17b9fa7d0b21, null);
+    assert.notEqual(certs['39596dc3a3f12aa74b481579e4ec944f86d24b95'], null);
+    scope.done();
     done();
   });
+});
 
-  it('should be able to retrieve a list of Google certificates', (done) => {
-    const scope =
-        nock('https://www.googleapis.com')
-            .get('/oauth2/v1/certs')
-            .replyWithFile(
-                200,
-                path.join(__dirname, '../../test/fixtures/oauthcerts.json'));
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.getFederatedSignonCerts((err, certs) => {
-      assert.equal(err, null);
-      assert.equal(Object.keys(certs).length, 2);
-      assert.notEqual(certs.a15eea964ab9cce480e5ef4f47cb17b9fa7d0b21, null);
-      assert.notEqual(certs['39596dc3a3f12aa74b481579e4ec944f86d24b95'], null);
-      scope.done();
-      done();
-    });
-  });
-
-  it('should be able to retrieve a list of Google certificates from cache again',
-     (done) => {
-       const scope =
-           nock('https://www.googleapis.com')
-               .defaultReplyHeaders({
-                 'Cache-Control':
-                     'public, max-age=23641, must-revalidate, no-transform',
-                 'Content-Type': 'application/json'
-               })
-               .get('/oauth2/v1/certs')
-               .once()
-               .replyWithFile(
-                   200,
-                   path.join(__dirname, '../../test/fixtures/oauthcerts.json'));
-       const oauth2client =
-           new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-       oauth2client.getFederatedSignonCerts((err, certs) => {
-         assert.equal(err, null);
-         assert.equal(Object.keys(certs).length, 2);
-         scope.done();  // has retrieved from nock... nock no longer will reply
-         oauth2client.getFederatedSignonCerts((err2, certs2) => {
-           assert.equal(err2, null);
-           assert.equal(Object.keys(certs2).length, 2);
-           scope.done();
-           done();
-         });
+it('should be able to retrieve a list of Google certificates from cache again',
+   done => {
+     const scope =
+         nock(certsBaseUrl)
+             .defaultReplyHeaders({
+               'Cache-Control':
+                   'public, max-age=23641, must-revalidate, no-transform',
+               'Content-Type': 'application/json'
+             })
+             .get(certsPath)
+             .replyWithFile(200, certsResPath);
+     client.getFederatedSignonCerts((err, certs) => {
+       assert.equal(err, null);
+       assert.equal(Object.keys(certs).length, 2);
+       scope.done();  // has retrieved from nock... nock no longer will reply
+       client.getFederatedSignonCerts((err2, certs2) => {
+         assert.equal(err2, null);
+         assert.equal(Object.keys(certs2).length, 2);
+         scope.done();
+         done();
        });
      });
+   });
 
-  it('should set redirect_uri if not provided in options', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const generated = oauth2client.generateAuthUrl({});
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.redirect_uri, REDIRECT_URI);
+it('should set redirect_uri if not provided in options', () => {
+  const generated = client.generateAuthUrl({});
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.redirect_uri, REDIRECT_URI);
+});
+
+it('should set client_id if not provided in options', () => {
+  const generated = client.generateAuthUrl({});
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.client_id, CLIENT_ID);
+});
+
+it('should override redirect_uri if provided in options', () => {
+  const generated = client.generateAuthUrl({redirect_uri: 'overridden'});
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.redirect_uri, 'overridden');
+});
+
+it('should override client_id if provided in options', () => {
+  const generated = client.generateAuthUrl({client_id: 'client_override'});
+  const parsed = url.parse(generated);
+  if (typeof parsed.query !== 'string') {
+    throw new Error('Unable to parse querystring');
+  }
+  const query = qs.parse(parsed.query);
+  assert.equal(query.client_id, 'client_override');
+});
+
+it('should return error in callback on request', done => {
+  client.request({}, (err, result) => {
+    assert.equal(err!.message, 'No access, refresh token or API key is set.');
+    assert.equal(result, null);
+    done();
   });
+});
 
-  it('should set client_id if not provided in options', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const generated = oauth2client.generateAuthUrl({});
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.client_id, CLIENT_ID);
+it('should return error in callback on refreshAccessToken', done => {
+  client.refreshAccessToken((err, result) => {
+    assert.equal(err!.message, 'No refresh token is set.');
+    assert.equal(result, null);
+    done();
   });
+});
 
-  it('should override redirect_uri if provided in options', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const generated =
-        oauth2client.generateAuthUrl({redirect_uri: 'overridden'});
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.redirect_uri, 'overridden');
+
+function mockExample() {
+  return [
+    nock('https://www.googleapis.com')
+        .post(
+            '/oauth2/v4/token', undefined,
+            {reqheaders: {'content-type': 'application/x-www-form-urlencoded'}})
+        .reply(200, {access_token: 'abc123', expires_in: 1}),
+    nock('http://example.com').get('/').reply(200)
+  ];
+}
+
+it('should refresh token if missing access token', (done) => {
+  const scopes = mockExample();
+  client.credentials = {refresh_token: 'refresh-token-placeholder'};
+  client.request({url: 'http://example.com'}, err => {
+    scopes.forEach(s => s.done());
+    assert.equal('abc123', client.credentials.access_token);
+    done();
   });
+});
 
-  it('should override client_id if provided in options', () => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    const generated =
-        oauth2client.generateAuthUrl({client_id: 'client_override'});
-    const parsed = url.parse(generated);
-    if (typeof parsed.query !== 'string') {
-      throw new Error('Unable to parse querystring');
-    }
-    const query = qs.parse(parsed.query);
-    assert.equal(query.client_id, 'client_override');
+it('should refresh if access token is expired', (done) => {
+  client.setCredentials({
+    access_token: 'initial-access-token',
+    refresh_token: 'refresh-token-placeholder',
+    expiry_date: (new Date()).getTime() - 1000
   });
+  const scopes = mockExample();
+  client.request({url: 'http://example.com'}, () => {
+    scopes.forEach(s => s.done());
+    assert.equal('abc123', client.credentials.access_token);
+    done();
+  });
+});
 
-  it('should return error in callback on request', (done) => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.request({}, (err, result) => {
-      assert.equal(err!.message, 'No access, refresh token or API key is set.');
-      assert.equal(result, null);
+
+it('should refresh if access token will expired soon and time to refresh before expiration is set',
+   async () => {
+     const client = new OAuth2Client({
+       clientId: CLIENT_ID,
+       clientSecret: CLIENT_SECRET,
+       redirectUri: REDIRECT_URI,
+       eagerRefreshThresholdMillis: 5000
+     });
+     client.credentials = {
+       access_token: 'initial-access-token',
+       refresh_token: 'refresh-token-placeholder',
+       expiry_date: (new Date()).getTime() + 3000
+     };
+     const scopes = mockExample();
+     await client.request({url: 'http://example.com'});
+     assert.equal('abc123', client.credentials.access_token);
+     scopes.forEach(s => s.done());
+   });
+
+it('should not refresh if access token will not expire soon and time to refresh before expiration is set',
+   async () => {
+     const client = new OAuth2Client({
+       clientId: CLIENT_ID,
+       clientSecret: CLIENT_SECRET,
+       redirectUri: REDIRECT_URI,
+       eagerRefreshThresholdMillis: 5000
+     });
+     client.credentials = {
+       access_token: 'initial-access-token',
+       refresh_token: 'refresh-token-placeholder',
+       expiry_date: (new Date()).getTime() + 10000,
+     };
+     const scopes = mockExample();
+     await client.request({url: 'http://example.com'});
+     assert.equal('initial-access-token', client.credentials.access_token);
+     assert.equal(false, scopes[0].isDone());
+     scopes[1].done();
+   });
+
+it('should not refresh if not expired', done => {
+  client.credentials = {
+    access_token: 'initial-access-token',
+    refresh_token: 'refresh-token-placeholder',
+    expiry_date: (new Date()).getTime() + 500000
+  };
+  const scopes = mockExample();
+  client.request({url: 'http://example.com'}, () => {
+    assert.equal('initial-access-token', client.credentials.access_token);
+    assert.equal(false, scopes[0].isDone());
+    scopes[1].done();
+    done();
+  });
+});
+
+it('should assume access token is not expired', done => {
+  client.credentials = {
+    access_token: 'initial-access-token',
+    refresh_token: 'refresh-token-placeholder'
+  };
+  const scopes = mockExample();
+  client.request({url: 'http://example.com'}, () => {
+    assert.equal('initial-access-token', client.credentials.access_token);
+    assert.equal(false, scopes[0].isDone());
+    scopes[1].done();
+    done();
+  });
+});
+
+[401, 403].forEach(code => {
+  it(`should refresh token if the server returns ${code}`, done => {
+    const scope = nock('http://example.com').get('/access').reply(code, {
+      error: {code, message: 'Invalid Credentials'}
+    });
+    const scopes = mockExample();
+    client.credentials = {
+      access_token: 'initial-access-token',
+      refresh_token: 'refresh-token-placeholder'
+    };
+    client.request({url: 'http://example.com/access'}, err => {
+      scope.done();
+      scopes[0].done();
+      assert.equal('abc123', client.credentials.access_token);
       done();
     });
   });
+});
 
-  it('should return error in callback on refreshAccessToken', (done) => {
-    const oauth2client =
-        new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.refreshAccessToken((err, result) => {
-      assert.equal(err!.message, 'No refresh token is set.');
-      assert.equal(result, null);
-      done();
-    });
+it('should not retry requests with streaming data', done => {
+  const s = fs.createReadStream('./test/fixtures/public.pem');
+  const scope = nock('http://example.com').post('/').reply(401);
+  client.credentials = {
+    access_token: 'initial-access-token',
+    refresh_token: 'refresh-token-placeholder'
+  };
+  client.request({method: 'POST', url: 'http://example.com', data: s}, err => {
+    scope.done();
+    const e = err as AxiosError;
+    assert(e);
+    assert.equal(e.response!.status, 401);
+    done();
   });
+});
 
-  describe('request()', () => {
-    let scope: nock.Scope;
-
-    beforeEach(() => {
-      scope = nock('https://www.googleapis.com')
-                  .post('/oauth2/v4/token', undefined, {
-                    reqheaders:
-                        {'content-type': 'application/x-www-form-urlencoded'}
-                  })
-                  .reply(200, {access_token: 'abc123', expires_in: 1});
-
-      nock('http://example.com').get('/').reply(200);
-    });
-
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    it('should refresh token if missing access token', (done) => {
-      const client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-      client.credentials = {refresh_token: 'refresh-token-placeholder'};
-      client.request({url: 'http://example.com'}, err => {
-        console.error(err);
-        assert.equal('abc123', client.credentials.access_token);
-        done();
-      });
-    });
-
-    it('should refresh if access token is expired', (done) => {
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-
-      oauth2client.setCredentials({
-        access_token: 'initial-access-token',
-        refresh_token: 'refresh-token-placeholder',
-        expiry_date: (new Date()).getTime() - 1000
-      });
-
-      oauth2client.request({url: 'http://example.com'}, () => {
-        assert.equal('abc123', oauth2client.credentials.access_token);
-        done();
-      });
-    });
-
-
-    it('should refresh if access token will expired soon and time to refresh' +
-           ' before expiration is set',
-       async () => {
-         const auth = new GoogleAuth();
-         const oauth2client = new OAuth2Client({
-           clientId: CLIENT_ID,
-           clientSecret: CLIENT_SECRET,
-           redirectUri: REDIRECT_URI,
-           eagerRefreshThresholdMillis: 5000
-         });
-
-         oauth2client.credentials = {
-           access_token: 'initial-access-token',
-           refresh_token: 'refresh-token-placeholder',
-           expiry_date: (new Date()).getTime() + 3000
-         };
-
-         await oauth2client.request({url: 'http://example.com'});
-         assert.equal('abc123', oauth2client.credentials.access_token);
-       });
-
-    it('should not refresh if access token will not expire soon and time to' +
-           ' refresh before expiration is set',
-       async () => {
-         const oauth2client = new OAuth2Client({
-           clientId: CLIENT_ID,
-           clientSecret: CLIENT_SECRET,
-           redirectUri: REDIRECT_URI,
-           eagerRefreshThresholdMillis: 5000
-         });
-
-         oauth2client.credentials = {
-           access_token: 'initial-access-token',
-           refresh_token: 'refresh-token-placeholder',
-           expiry_date: (new Date()).getTime() + 10000,
-         };
-
-         await oauth2client.request({url: 'http://example.com'});
-
-         assert.equal(
-             'initial-access-token', oauth2client.credentials.access_token);
-         assert.equal(false, scope.isDone());
-       });
-
-    it('should not refresh if not expired', (done) => {
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-
-      oauth2client.credentials = {
-        access_token: 'initial-access-token',
-        refresh_token: 'refresh-token-placeholder',
-        expiry_date: (new Date()).getTime() + 500000
-      };
-
-      oauth2client.request({url: 'http://example.com'}, () => {
-        assert.equal(
-            'initial-access-token', oauth2client.credentials.access_token);
-        assert.equal(false, scope.isDone());
-        done();
-      });
-    });
-
-    it('should assume access token is not expired', (done) => {
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-
-      oauth2client.credentials = {
-        access_token: 'initial-access-token',
-        refresh_token: 'refresh-token-placeholder'
-      };
-
-      oauth2client.request({url: 'http://example.com'}, () => {
-        assert.equal(
-            'initial-access-token', oauth2client.credentials.access_token);
-        assert.equal(false, scope.isDone());
-        done();
-      });
-    });
-
-    [401, 403].forEach((statusCode) => {
-      it('should refresh token if the server returns ' + statusCode, (done) => {
-        nock('http://example.com').get('/access').reply(statusCode, {
-          error: {code: statusCode, message: 'Invalid Credentials'}
-        });
-
-        const oauth2client =
-            new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-
-        oauth2client.credentials = {
-          access_token: 'initial-access-token',
-          refresh_token: 'refresh-token-placeholder'
-        };
-
-        oauth2client.request({url: 'http://example.com/access'}, () => {
-          assert.equal('abc123', oauth2client.credentials.access_token);
-          done();
-        });
-      });
-    });
-
-    it('should not retry requests with streaming data', (done) => {
-      const s = fs.createReadStream('./test/fixtures/public.pem');
-      nock('http://example.com').post('/').reply(401);
-      const client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-      client.credentials = {
-        access_token: 'initial-access-token',
-        refresh_token: 'refresh-token-placeholder'
-      };
-      client.request(
-          {method: 'POST', url: 'http://example.com', data: s}, err => {
-            const e = err as AxiosError;
-            assert(e);
-            assert.equal(e.response!.status, 401);
-            done();
-          });
-    });
+it('should revoke credentials if access token present', done => {
+  const scope = nock('https://accounts.google.com')
+                    .get('/o/oauth2/revoke?token=abc')
+                    .reply(200, {success: true});
+  client.credentials = {access_token: 'abc', refresh_token: 'abc'};
+  client.revokeCredentials((err, result) => {
+    assert.equal(err, null);
+    assert.equal(result!.data!.success, true);
+    assert.equal(JSON.stringify(client.credentials), '{}');
+    scope.done();
+    done();
   });
+});
 
-  describe('revokeCredentials()', () => {
-    it('should revoke credentials if access token present', (done) => {
-      const scope = nock('https://accounts.google.com')
-                        .get('/o/oauth2/revoke?token=abc')
-                        .reply(200, {success: true});
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-      oauth2client.credentials = {access_token: 'abc', refresh_token: 'abc'};
-      oauth2client.revokeCredentials((err, result) => {
-        assert.equal(err, null);
-        assert.equal(result!.data!.success, true);
-        assert.equal(JSON.stringify(oauth2client.credentials), '{}');
-        scope.done();
-        done();
-      });
-    });
+it('should clear credentials and return error if no access token to revoke',
+   done => {
+     client.credentials = {refresh_token: 'abc'};
+     client.revokeCredentials((err, result) => {
+       assert.equal(err!.message, 'No access token to revoke.');
+       assert.equal(result, null);
+       assert.equal(JSON.stringify(client.credentials), '{}');
+       done();
+     });
+   });
 
-    it('should clear credentials and return error if no access token to revoke',
-       (done) => {
-         const oauth2client =
-             new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-         oauth2client.credentials = {refresh_token: 'abc'};
-         oauth2client.revokeCredentials((err, result) => {
-           assert.equal(err!.message, 'No access token to revoke.');
-           assert.equal(result, null);
-           assert.equal(JSON.stringify(oauth2client.credentials), '{}');
-           done();
-         });
-       });
-  });
-
-  describe('getToken()', () => {
-    it('should allow a code_verifier to be passed', async () => {
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+it('getToken should allow a code_verifier to be passed', async () => {
+  const scope =
       nock('https://www.googleapis.com')
           .post('/oauth2/v4/token', undefined, {
             reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
           })
           .reply(
               200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
-      const res = await oauth2client.getToken(
-          {code: 'code here', codeVerifier: 'its_verified'});
-      assert(res.res);
-      if (!res.res) return;
-      const params = qs.parse(res.res.config.data);
-      assert(params.code_verifier === 'its_verified');
-    });
+  const res =
+      await client.getToken({code: 'code here', codeVerifier: 'its_verified'});
+  scope.done();
+  assert(res.res);
+  if (!res.res) return;
+  const params = qs.parse(res.res.config.data);
+  assert(params.code_verifier === 'its_verified');
+});
 
-    it('should return expiry_date', (done) => {
-      const now = (new Date()).getTime();
-      const scope =
-          nock('https://www.googleapis.com')
-              .post('/oauth2/v4/token', undefined, {
-                reqheaders:
-                    {'Content-Type': 'application/x-www-form-urlencoded'}
-              })
-              .reply(
-                  200,
-                  {access_token: 'abc', refresh_token: '123', expires_in: 10});
-      const oauth2client =
-          new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-      oauth2client.getToken('code here', (err, tokens) => {
-        assert(tokens!.expiry_date! >= now + (10 * 1000));
-        assert(tokens!.expiry_date! <= now + (15 * 1000));
-        scope.done();
-        done();
-      });
-    });
-
-    it('should accept custom authBaseUrl and tokenUrl', async () => {
-      const authBaseUrl = 'http://authBaseUrl.com';
-      const tokenUrl = 'http://tokenUrl.com';
-      const oauth2client = new OAuth2Client(
-          CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, {authBaseUrl, tokenUrl});
-
-      const authUrl = oauth2client.generateAuthUrl();
-      const authUrlParts = url.parse(authUrl);
-      assert.equal(
-          authBaseUrl.toLowerCase(),
-          authUrlParts.protocol + '//' + authUrlParts.hostname);
-
-      nock(tokenUrl).post('/').reply(200, {});
-      const result = await oauth2client.getToken('12345');
-    });
+it('should return expiry_date', done => {
+  const now = (new Date()).getTime();
+  const scope =
+      nock('https://www.googleapis.com')
+          .post('/oauth2/v4/token', undefined, {
+            reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
+          })
+          .reply(
+              200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
+  client.getToken('code here', (err, tokens) => {
+    assert(tokens!.expiry_date! >= now + (10 * 1000));
+    assert(tokens!.expiry_date! <= now + (15 * 1000));
+    scope.done();
+    done();
   });
+});
+
+it('should accept custom authBaseUrl and tokenUrl', async () => {
+  const authBaseUrl = 'http://authBaseUrl.com';
+  const tokenUrl = 'http://tokenUrl.com';
+  const client = new OAuth2Client(
+      CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, {authBaseUrl, tokenUrl});
+  const authUrl = client.generateAuthUrl();
+  const authUrlParts = url.parse(authUrl);
+  assert.equal(
+      authBaseUrl.toLowerCase(),
+      authUrlParts.protocol + '//' + authUrlParts.hostname);
+  const scope = nock(tokenUrl).post('/').reply(200, {});
+  const result = await client.getToken('12345');
+  scope.done();
 });

--- a/test/test.refresh.ts
+++ b/test/test.refresh.ts
@@ -16,11 +16,7 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as nock from 'nock';
-
-import {GoogleAuth, UserRefreshClient} from '../src/index';
-
-nock.disableNetConnect();
+import {UserRefreshClient} from '../src/';
 
 // Creates a standard JSON credentials object for testing.
 function createJSON() {
@@ -32,105 +28,98 @@ function createJSON() {
   };
 }
 
-describe('.fromJson', () => {
-  it('should error on null json', () => {
-    const refresh = new UserRefreshClient();
-    assert.throws(() => {
-      // Test verifies invalid parameter tests, which requires cast to any.
-      // tslint:disable-next-line no-any
-      (refresh as any).fromJSON(null);
-    });
-  });
-
-  it('should error on empty json', () => {
-    const refresh = new UserRefreshClient();
-    assert.throws(() => {
-      // Test verifies invalid parameter tests, which requires cast to any.
-      // tslint:disable-next-line no-any
-      refresh.fromJSON({});
-    });
-  });
-
-  it('should error on missing client_id', () => {
-    const json = createJSON();
-    delete json.client_id;
-    const refresh = new UserRefreshClient();
-    assert.throws(() => {
-      refresh.fromJSON(json);
-    });
-  });
-
-  it('should error on missing client_secret', () => {
-    const json = createJSON();
-    delete json.client_secret;
-    const refresh = new UserRefreshClient();
-    assert.throws(() => {
-      refresh.fromJSON(json);
-    });
-  });
-
-  it('should error on missing refresh_token', () => {
-    const json = createJSON();
-    delete json.refresh_token;
-    const refresh = new UserRefreshClient();
-    assert.throws(() => {
-      refresh.fromJSON(json);
-    });
-  });
-
-  it('should create UserRefreshClient with clientId_', () => {
-    const json = createJSON();
-    const refresh = new UserRefreshClient();
-    const result = refresh.fromJSON(json);
-    assert.equal(json.client_id, refresh._clientId);
-  });
-
-  it('should create UserRefreshClient with clientSecret_', () => {
-    const json = createJSON();
-    const refresh = new UserRefreshClient();
-    const result = refresh.fromJSON(json);
-    assert.equal(json.client_secret, refresh._clientSecret);
-  });
-
-  it('should create UserRefreshClient with _refreshToken', () => {
-    const json = createJSON();
-    const refresh = new UserRefreshClient();
-    const result = refresh.fromJSON(json);
-    assert.equal(json.refresh_token, refresh._refreshToken);
+it('fromJSON should error on null json', () => {
+  const refresh = new UserRefreshClient();
+  assert.throws(() => {
+    // Test verifies invalid parameter tests, which requires cast to any.
+    // tslint:disable-next-line no-any
+    (refresh as any).fromJSON(null);
   });
 });
 
-describe('.fromStream', () => {
-  it('should error on null stream', (done) => {
-    const refresh = new UserRefreshClient();
+it('fromJSON should error on empty json', () => {
+  const refresh = new UserRefreshClient();
+  assert.throws(() => {
     // Test verifies invalid parameter tests, which requires cast to any.
     // tslint:disable-next-line no-any
-    (refresh as any).fromStream(null, (err: Error) => {
-      assert.equal(true, err instanceof Error);
-      done();
-    });
+    refresh.fromJSON({});
   });
+});
 
-  it('should read the stream and create a UserRefreshClient', (done) => {
-    // Read the contents of the file into a json object.
-    const fileContents =
-        fs.readFileSync('./test/fixtures/refresh.json', 'utf-8');
-    const json = JSON.parse(fileContents);
+it('fromJSON should error on missing client_id', () => {
+  const json = createJSON();
+  delete json.client_id;
+  const refresh = new UserRefreshClient();
+  assert.throws(() => {
+    refresh.fromJSON(json);
+  });
+});
 
-    // Now open a stream on the same file.
-    const stream = fs.createReadStream('./test/fixtures/refresh.json');
+it('fromJSON should error on missing client_secret', () => {
+  const json = createJSON();
+  delete json.client_secret;
+  const refresh = new UserRefreshClient();
+  assert.throws(() => {
+    refresh.fromJSON(json);
+  });
+});
 
-    // And pass it into the fromStream method.
-    const refresh = new UserRefreshClient();
-    refresh.fromStream(stream, (err) => {
-      assert.ifError(err);
+it('fromJSON should error on missing refresh_token', () => {
+  const json = createJSON();
+  delete json.refresh_token;
+  const refresh = new UserRefreshClient();
+  assert.throws(() => {
+    refresh.fromJSON(json);
+  });
+});
 
-      // Ensure that the correct bits were pulled from the stream.
-      assert.equal(json.client_id, refresh._clientId);
-      assert.equal(json.client_secret, refresh._clientSecret);
-      assert.equal(json.refresh_token, refresh._refreshToken);
+it('fromJSON should create UserRefreshClient with clientId_', () => {
+  const json = createJSON();
+  const refresh = new UserRefreshClient();
+  const result = refresh.fromJSON(json);
+  assert.equal(json.client_id, refresh._clientId);
+});
 
-      done();
-    });
+it('fromJSON should create UserRefreshClient with clientSecret_', () => {
+  const json = createJSON();
+  const refresh = new UserRefreshClient();
+  const result = refresh.fromJSON(json);
+  assert.equal(json.client_secret, refresh._clientSecret);
+});
+
+it('fromJSON should create UserRefreshClient with _refreshToken', () => {
+  const json = createJSON();
+  const refresh = new UserRefreshClient();
+  const result = refresh.fromJSON(json);
+  assert.equal(json.refresh_token, refresh._refreshToken);
+});
+
+it('fromStream should error on null stream', done => {
+  const refresh = new UserRefreshClient();
+  // Test verifies invalid parameter tests, which requires cast to any.
+  // tslint:disable-next-line no-any
+  (refresh as any).fromStream(null, (err: Error) => {
+    assert.equal(true, err instanceof Error);
+    done();
+  });
+});
+
+it('fromStream should read the stream and create a UserRefreshClient', done => {
+  // Read the contents of the file into a json object.
+  const fileContents = fs.readFileSync('./test/fixtures/refresh.json', 'utf-8');
+  const json = JSON.parse(fileContents);
+
+  // Now open a stream on the same file.
+  const stream = fs.createReadStream('./test/fixtures/refresh.json');
+
+  // And pass it into the fromStream method.
+  const refresh = new UserRefreshClient();
+  refresh.fromStream(stream, (err) => {
+    assert.ifError(err);
+    // Ensure that the correct bits were pulled from the stream.
+    assert.equal(json.client_id, refresh._clientId);
+    assert.equal(json.client_secret, refresh._clientSecret);
+    assert.equal(json.refresh_token, refresh._refreshToken);
+    done();
   });
 });

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -23,172 +23,156 @@ import {DefaultTransporter, RequestError} from '../src/transporters';
 // tslint:disable-next-line no-var-requires
 const version = require('../../package.json').version;
 
+const savedEnv = process.env;
+afterEach(() => {
+  process.env = savedEnv;
+});
+
 nock.disableNetConnect();
 
-describe('Transporters', () => {
-  const defaultUserAgentRE = 'google-api-nodejs-client/\\d+.\\d+.\\d+';
-  const transporter = new DefaultTransporter();
+const defaultUserAgentRE = 'google-api-nodejs-client/\\d+.\\d+.\\d+';
+const transporter = new DefaultTransporter();
 
-  it('should set default client user agent if none is set', () => {
-    const opts = transporter.configure();
-    const re = new RegExp(defaultUserAgentRE);
-    assert(re.test(opts.headers!['User-Agent']));
+it('should set default client user agent if none is set', () => {
+  const opts = transporter.configure();
+  const re = new RegExp(defaultUserAgentRE);
+  assert(re.test(opts.headers!['User-Agent']));
+});
+
+it('should append default client user agent to the existing user agent', () => {
+  const applicationName = 'MyTestApplication-1.0';
+  const opts = transporter.configure(
+      {headers: {'User-Agent': applicationName}, url: ''});
+  const re = new RegExp(applicationName + ' ' + defaultUserAgentRE);
+  assert(re.test(opts.headers!['User-Agent']));
+});
+
+it('should not append default client user agent to the existing user agent more than once',
+   () => {
+     const appName =
+         'MyTestApplication-1.0 google-api-nodejs-client/' + version;
+     const opts =
+         transporter.configure({headers: {'User-Agent': appName}, url: ''});
+     assert.equal(opts.headers!['User-Agent'], appName);
+   });
+
+it('should create a single error from multiple response errors', done => {
+  const firstError = {message: 'Error 1'};
+  const secondError = {message: 'Error 2'};
+  nock('http://example.com').get('/api').reply(400, {
+    error: {code: 500, errors: [firstError, secondError]}
   });
+  transporter.request(
+      {
+        url: 'http://example.com/api',
+      },
+      (error) => {
+        assert.strictEqual(error!.message, 'Error 1\nError 2');
+        assert.equal((error as RequestError).code, 500);
+        assert.equal((error as RequestError).errors.length, 2);
+        done();
+      });
+});
 
-  it('should append default client user agent to the existing user agent',
-     () => {
-       const applicationName = 'MyTestApplication-1.0';
-       const opts = transporter.configure(
-           {headers: {'User-Agent': applicationName}, url: ''});
-       const re = new RegExp(applicationName + ' ' + defaultUserAgentRE);
-       assert(re.test(opts.headers!['User-Agent']));
-     });
-
-  it('should not append default client user agent to the existing user agent more than once',
-     () => {
-       const applicationName =
-           'MyTestApplication-1.0 google-api-nodejs-client/' + version;
-       const opts = transporter.configure(
-           {headers: {'User-Agent': applicationName}, url: ''});
-       assert.equal(opts.headers!['User-Agent'], applicationName);
-     });
-
-  it('should create a single error from multiple response errors', (done) => {
-    const firstError = {message: 'Error 1'};
-    const secondError = {message: 'Error 2'};
-    nock('http://example.com').get('/api').reply(400, {
-      error: {code: 500, errors: [firstError, secondError]}
-    });
-    transporter.request(
-        {
-          url: 'http://example.com/api',
-        },
-        (error) => {
-          assert.strictEqual(error!.message, 'Error 1\nError 2');
-          assert.equal((error as RequestError).code, 500);
-          assert.equal((error as RequestError).errors.length, 2);
-          done();
-        });
-  });
-
-  it('should return an error for a 404 response', (done) => {
-    nock('http://example.com').get('/api').reply(404, 'Not found');
-    transporter.request(
-        {
-          url: 'http://example.com/api',
-        },
-        (error) => {
-          assert.strictEqual(error!.message, 'Not found');
-          assert.equal((error as RequestError).code, 404);
-          done();
-        });
-  });
-
-  it('should return an error if you try to use request config options', (done) => {
-    const expected =
-        '\'uri\' is not a valid configuration option. Please use \'url\' instead. This library is using Axios for requests. Please see https://github.com/axios/axios to learn more about the valid request options.';
-    transporter.request(
-        {
-          uri: 'http://example.com/api',
-        } as AxiosRequestConfig,
-        (error) => {
-          assert.equal(error!.message, expected);
-          done();
-        });
-  });
-
-  it('should return an error if you try to use request config options with a promise',
-     async () => {
-       const expected =
-           '\'uri\' is not a valid configuration option. Please use \'url\' instead. This library is using Axios for requests. Please see https://github.com/axios/axios to learn more about the valid request options.';
-       try {
-         await transporter.request({
-           uri: 'http://example.com/api',
-         } as AxiosRequestConfig);
-       } catch (e) {
-         assert.equal(e.message, expected);
-         return;
-       }
-       throw new Error('Expected to throw');
-     });
-
-
-
-  it('should support invocation with async/await', async () => {
-    const url = 'http://example.com';
-    const scope = nock(url).get('/').reply(200);
-    const res = await transporter.request({url});
-    assert.equal(res.status, 200);
-  });
-
-  it('should throw if using async/await', async () => {
-    const url = 'http://example.com';
-    const scope = nock(url).get('/').reply(500, 'florg');
-    try {
-      await transporter.request({url});
-    } catch (e) {
-      assert.equal(e.message, 'florg');
-      return;
-    }
-    throw new Error('Expected to throw');
-  });
-
-  it('should work with a callback', done => {
-    const url = 'http://example.com';
-    const scope = nock(url).get('/').reply(200);
-    transporter.request({url}, (err, res) => {
-      assert.equal(err, null);
-      assert.equal(res!.status, 200);
-      done();
-    });
+it('should return an error for a 404 response', done => {
+  const url = 'http://example.com';
+  nock(url).get('/').reply(404, 'Not found');
+  transporter.request({url}, error => {
+    assert.strictEqual(error!.message, 'Not found');
+    assert.equal((error as RequestError).code, 404);
+    done();
   });
 });
 
-describe('transporter proxy', () => {
-  let savedEnv: NodeJS.ProcessEnv;
+it('should return an error if you try to use request config options', done => {
+  const expected =
+      '\'uri\' is not a valid configuration option. Please use \'url\' instead. This library is using Axios for requests. Please see https://github.com/axios/axios to learn more about the valid request options.';
+  transporter.request(
+      {
+        uri: 'http://example.com/api',
+      } as AxiosRequestConfig,
+      (error) => {
+        assert.equal(error!.message, expected);
+        done();
+      });
+});
 
-  beforeEach(() => {
-    savedEnv = process.env;
-    process.env = {};
-  });
+it('should return an error if you try to use request config options with a promise',
+   async () => {
+     const expected =
+         '\'uri\' is not a valid configuration option. Please use \'url\' instead. This library is using Axios for requests. Please see https://github.com/axios/axios to learn more about the valid request options.';
+     try {
+       await transporter.request({
+         uri: 'http://example.com/api',
+       } as AxiosRequestConfig);
+     } catch (e) {
+       assert.equal(e.message, expected);
+       return;
+     }
+     throw new Error('Expected to throw');
+   });
 
-  afterEach(() => {
-    process.env = savedEnv;
-  });
+it('should support invocation with async/await', async () => {
+  const url = 'http://example.com';
+  const scope = nock(url).get('/').reply(200);
+  const res = await transporter.request({url});
+  assert.equal(res.status, 200);
+});
 
-  it('should use the http proxy if one is configured', async () => {
-    process.env['http_proxy'] = 'http://han:solo@proxy-server:1234';
-    const transporter = new DefaultTransporter();
-    nock('http://proxy-server:1234')
-        .get('http://example.com/fake', undefined, {
-          reqheaders: {
-            'host': 'example.com',
-            'accept': /.*/g,
-            'user-agent': /google-api-nodejs-client\/.*/g,
-            'proxy-authorization': /.*/g
-          }
-        })
-        .reply(200);
-    const url = 'http://example.com/fake';
-    const result = await transporter.request({url});
-    assert.equal(result.status, 200);
-  });
+it('should throw if using async/await', async () => {
+  const url = 'http://example.com';
+  const scope = nock(url).get('/').reply(500, 'florg');
+  try {
+    await transporter.request({url});
+  } catch (e) {
+    assert.equal(e.message, 'florg');
+    return;
+  }
+  throw new Error('Expected to throw');
+});
 
-  it('should use the https proxy if one is configured', async () => {
-    process.env['https_proxy'] = 'https://han:solo@proxy-server:1234';
-    const transporter = new DefaultTransporter();
-    nock('https://proxy-server:1234')
-        .get('https://example.com/fake', undefined, {
-          reqheaders: {
-            'host': 'example.com',
-            'accept': /.*/g,
-            'user-agent': /google-api-nodejs-client\/.*/g,
-            'proxy-authorization': /.*/g
-          }
-        })
-        .reply(200);
-    const url = 'https://example.com/fake';
-    const result = await transporter.request({url});
-    assert.equal(result.status, 200);
+it('should work with a callback', done => {
+  const url = 'http://example.com';
+  const scope = nock(url).get('/').reply(200);
+  transporter.request({url}, (err, res) => {
+    assert.equal(err, null);
+    assert.equal(res!.status, 200);
+    done();
   });
+});
+
+it('should use the http proxy if one is configured', async () => {
+  process.env['http_proxy'] = 'http://han:solo@proxy-server:1234';
+  const transporter = new DefaultTransporter();
+  nock('http://proxy-server:1234')
+      .get('http://example.com/fake', undefined, {
+        reqheaders: {
+          'host': 'example.com',
+          'accept': /.*/g,
+          'user-agent': /google-api-nodejs-client\/.*/g,
+          'proxy-authorization': /.*/g
+        }
+      })
+      .reply(200);
+  const url = 'http://example.com/fake';
+  const result = await transporter.request({url});
+  assert.equal(result.status, 200);
+});
+
+it('should use the https proxy if one is configured', async () => {
+  process.env['https_proxy'] = 'https://han:solo@proxy-server:1234';
+  const transporter = new DefaultTransporter();
+  nock('https://proxy-server:1234')
+      .get('https://example.com/fake', undefined, {
+        reqheaders: {
+          'host': 'example.com',
+          'accept': /.*/g,
+          'user-agent': /google-api-nodejs-client\/.*/g,
+          'proxy-authorization': /.*/g
+        }
+      })
+      .reply(200);
+  const url = 'https://example.com/fake';
+  const result = await transporter.request({url});
+  assert.equal(result.status, 200);
 });


### PR DESCRIPTION
This change flattens out the structure of our tests, dropping the `describe` calls.  Doing this in preparation for a move over to ava, which doesn't support nested describe blocks.  Did a little cleanup along the way.  