### PR TITLE
chore: drop support for node.js 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node4:
-          filters: *release_tags
       - node6:
           filters: *release_tags
       - node8:
@@ -33,7 +31,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
             - node9
@@ -43,11 +40,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-        user: node
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es2016"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
BREAKING CHANGE: This change removes support for Node.js 4.x.  

Note sure if we want to put these changes in another branch or not.  (Probably a good idea)