### PR TITLE
chore: rename `credential` to `client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,43 +56,15 @@ The code below shows how to retrieve a default credential type, depending upon t
 
 ```js
 const {auth} = require('google-auth-library');
-
-/**
- * Acquire a client, and make a request to an API that's enabled by default.
- */
 async function main() {
-  const adc = await getADC();
-  const url = `https://www.googleapis.com/dns/v1/projects/${adc.projectId}`;
-  const res = await adc.client.request({url});
+  const client = await auth.getClient();
+  const projectId = await auth.getDefaultProjectId();
+  const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
+  const res = await client.request({ url });
   console.log(res.data);
 }
-
-/**
- * Instead of specifying the type of client you'd like to use (JWT, OAuth2, etc)
- * this library will automatically choose the right client based on the environment.
- */
-async function getADC() {
-  // Acquire a client and the projectId based on the environment. This method looks
-  // for the GCLOUD_PROJECT and GOOGLE_APPLICATION_CREDENTIALS environment variables.
-  const res = await auth.getApplicationDefault();
-  let client = res.credential;
-
-  // The createScopedRequired method returns true when running on GAE or a local developer
-  // machine. In that case, the desired scopes must be passed in manually. When the code is
-  // running in GCE or a Managed VM, the scopes are pulled from the GCE metadata server.
-  // See https://cloud.google.com/compute/docs/authentication for more information.
-  if (client.createScopedRequired && client.createScopedRequired()) {
-    // Scopes can be specified either as an array or as a single, space-delimited string.
-    const scopes = ['https://www.googleapis.com/auth/cloud-platform'];
-    client = client.createScoped(scopes);
-  }
-  return {
-    client: client,
-    projectId: res.projectId
-  }
-}
-
 main().catch(console.error);
+
 ```
 
 #### OAuth2 client

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -217,9 +217,8 @@ export class GoogleAuth {
     // Check for the existence of a local environment variable pointing to the
     // location of the credential file. This is typically used in local
     // developer scenarios.
-    client =
-        await this._tryGetApplicationCredentialsFromEnvironmentVariable(
-            options);
+    client = await this._tryGetApplicationCredentialsFromEnvironmentVariable(
+        options);
     if (client) {
       this.cachedClient = client;
       projectId = await this.getDefaultProjectId();
@@ -227,8 +226,7 @@ export class GoogleAuth {
     }
 
     // Look in the well-known credential file location.
-    client =
-        await this._tryGetApplicationCredentialsFromWellKnownFile(options);
+    client = await this._tryGetApplicationCredentialsFromWellKnownFile(options);
     if (client) {
       this.cachedClient = client;
       projectId = await this.getDefaultProjectId();

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -926,22 +926,22 @@ it('getApplicationDefault should return a new credential the first time and a ca
      assert.notEqual(null, result);
 
      // Capture the returned credential.
-     const cachedCredential = result.credential;
+     const cachedClient = result.client;
 
      // Make sure our special test bit is not set yet, indicating that
      // this is a new credentials instance.
      // Test verifies invalid parameter tests, which requires cast to any.
      // tslint:disable-next-line no-any
-     assert.equal(null, (cachedCredential as any).specialTestBit);
+     assert.equal(null, (cachedClient as any).specialTestBit);
 
      // Now set the special test bit.
      // Test verifies invalid parameter tests, which requires cast to any.
      // tslint:disable-next-line no-any
-     (cachedCredential as any).specialTestBit = 'monkey';
+     (cachedClient as any).specialTestBit = 'monkey';
 
      // Ask for credentials again, from the same auth instance. We expect
      // a cached instance this time.
-     const result2 = (await auth.getApplicationDefault()).credential;
+     const result2 = (await auth.getApplicationDefault()).client;
      assert.notEqual(null, result2);
 
      // Make sure the special test bit is set on the credentials we got
@@ -951,14 +951,14 @@ it('getApplicationDefault should return a new credential the first time and a ca
      // any.
      // tslint:disable-next-line no-any
      assert.equal('monkey', (result2 as any).specialTestBit);
-     assert.equal(cachedCredential, result2);
+     assert.equal(cachedClient, result2);
 
      // Now create a second GoogleAuth instance, and ask for
      // credentials. We should get a new credentials instance this time.
      const auth2 = new GoogleAuth();
      auth2._fileExists = () => false;
 
-     const result3 = (await auth2.getApplicationDefault()).credential;
+     const result3 = (await auth2.getApplicationDefault()).client;
      assert.notEqual(null, result3);
 
      // Make sure we get a new (non-cached) credential instance back.
@@ -966,7 +966,7 @@ it('getApplicationDefault should return a new credential the first time and a ca
      // any.
      // tslint:disable-next-line no-any
      assert.equal(null, (result3 as any).specialTestBit);
-     assert.notEqual(cachedCredential, result3);
+     assert.notEqual(cachedClient, result3);
    });
 
 it('getApplicationDefault should cache the credential when using GCE',
@@ -978,11 +978,11 @@ it('getApplicationDefault should cache the credential when using GCE',
      assert.notEqual(null, result);
 
      // Capture the returned credential.
-     const cachedCredential = result.credential;
+     const cachedCredential = result.client;
 
      // Ask for credentials again, from the same auth instance. We expect
      // a cached instance this time.
-     const result2 = (await auth.getApplicationDefault()).credential;
+     const result2 = (await auth.getApplicationDefault()).client;
      assert.notEqual(null, result2);
 
      // Make sure it's the same object
@@ -1279,7 +1279,7 @@ it('getCredentials should handle valid file path', async () => {
       './test/fixtures/private2.json');
   const result = await auth.getApplicationDefault();
   assert(result);
-  const jwt = result.credential as JWT;
+  const jwt = result.client as JWT;
   it('should return the credentials from file', async () => {
     const body = await auth.getCredentials();
     assert.notEqual(null, body);


### PR DESCRIPTION
BREAKING CHANGE:  Renames the `credential` field on the `ADCResponse` to `client`.  Previous code like this:

```js
const res = await auth.getApplicationDefault();	
const client = res.credential;	
```

Now will look like this:

```js
const res = await auth.getApplicationDefault();	
const client = res.client;	
```

Resolves #298.   