### PR TITLE
fix: limit situations where we retry

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -680,7 +680,6 @@ export class OAuth2Client extends AuthClient {
         opts.headers = opts.headers || {};
         opts.headers.Authorization = r.headers.Authorization;
       }
-
       if (this.apiKey) {
         opts.params = Object.assign(opts.params || {}, {key: this.apiKey});
       }
@@ -689,16 +688,21 @@ export class OAuth2Client extends AuthClient {
       const res = (e as AxiosError).response;
       if (res) {
         const statusCode = res.status;
-        // Automatically retry 401 and 403 responses if err is set and is
-        // unrelated to response then getting credentials failed, and retrying
-        // won't help
+        // Retry the request for metadata if the following criteria are true:
+        // - We haven't already retried.  It only makes sense to retry once.
+        // - The response was a 401 or a 403
+        // - The request didn't send a readableStream
+        // - An access_token and refresh_token were available, but no
+        // expiry_date
+        //   was availabe.  This can happen when developers stash the
+        //   access_token and refresh_token for later use, but the access_token
+        //   fails on the first try because it's expired.
+        const mayRequireRefresh = this.credentials &&
+            this.credentials.access_token && this.credentials.refresh_token &&
+            !this.credentials.expiry_date;
         const isReadableStream = res.config.data instanceof stream.Readable;
-        if (!retry && (statusCode === 401 || statusCode === 403) &&
-            !isReadableStream) {
-          /* It only makes sense to retry once, because the retry is intended
-           * to handle expiration-related failures. If refreshing the token
-           * does not fix the failure, then refreshing again probably won't
-           * help */
+        const isAuthErr = statusCode === 401 || statusCode === 403;
+        if (!retry && isAuthErr && !isReadableStream && mayRequireRefresh) {
           await this.refreshAccessTokenAsync();
           return this.requestAsync<T>(opts, true);
         }

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -150,11 +150,10 @@ it('should return false for createScopedRequired', () => {
 });
 
 it('should return a helpful message on request response.statusCode 403', done => {
-  // Mock the credentials object.
+  // Mock the credentials object.  Make sure there's no expiry_date set.
   compute.credentials = {
     refresh_token: 'hello',
     access_token: 'goodbye',
-    expiry_date: (new Date(9999, 1, 1)).getTime()
   };
 
   nock('http://foo').get('/').twice().reply(403, 'a weird response body');


### PR DESCRIPTION
Resolves #290. This is the one where retrying the request on 401/403 was causing all kinds of trouble.  After taking a closer look, I think we should keep the retries, but only in the situation where a user has set an access_token, a refresh_token, and they don't have an expiry_date.  This can happen if the user stashes a refresh and access token for later use, and then populates it manually at a later point.  That's the only real case I can think of where retrying getRequestMetadata is useful beyond what's there today. 
