### PR TITLE
chore: prefer undefined over null

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "scripts": {
-    "test": "nyc mocha build/test",
+    "test": "nyc mocha --timeout 10000 build/test",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
     "clean": "gts clean",
     "prepare": "npm run compile",

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -62,11 +62,11 @@ export class Compute extends OAuth2Client {
    * Refreshes the access token.
    * @param refreshToken Unused parameter
    */
-  protected async refreshToken(refreshToken?: string|
-                               null): Promise<GetTokenResponse> {
+  protected async refreshToken(refreshToken?: string):
+      Promise<GetTokenResponse> {
     const url = this.tokenUrl ||
         `${gcpMetadata.HOST_ADDRESS}${Compute._GOOGLE_OAUTH2_TOKEN_URL}`;
-    let res: AxiosResponse<CredentialRequest>|null = null;
+    let res: AxiosResponse<CredentialRequest>;
     // request for new token
     try {
       // TODO: In 2.0, we should remove the ability to configure the tokenUrl,
@@ -95,7 +95,7 @@ export class Compute extends OAuth2Client {
     return super.requestAsync<T>(opts, retry).catch(e => {
       const res = (e as AxiosError).response;
       if (res && res.status) {
-        let helpfulMessage = null;
+        let helpfulMessage: string|undefined;
         if (res.status === 403) {
           helpfulMessage =
               'A Forbidden error was returned while attempting to retrieve an access ' +

--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -15,11 +15,11 @@
  */
 
 export interface Credentials {
-  refresh_token?: string|null;
-  expiry_date?: number|null;
-  access_token?: string|null;
-  token_type?: string|null;
-  id_token?: string|null;
+  refresh_token?: string;
+  expiry_date?: number;
+  access_token?: string;
+  token_type?: string;
+  id_token?: string;
 }
 
 export interface CredentialRequest {

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -21,8 +21,8 @@ import {JWTInput} from './credentials';
 import {RequestMetadataResponse} from './oauth2client';
 
 export class JWTAccess {
-  email?: string|null;
-  key?: string|null;
+  email?: string;
+  key?: string;
   projectId?: string;
 
   private cache =
@@ -37,7 +37,7 @@ export class JWTAccess {
    * @param email the service account email address.
    * @param key the private key that will be used to sign the token.
    */
-  constructor(email?: string|null, key?: string|null) {
+  constructor(email?: string, key?: string) {
     this.email = email;
     this.key = key;
   }

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -95,7 +95,7 @@ export class JWT extends OAuth2Client {
    *
    * @param url the URI being authorized.
    */
-  protected async getRequestMetadataAsync(url?: string|null):
+  protected async getRequestMetadataAsync(url?: string):
       Promise<RequestMetadataResponse> {
     if (!this.apiKey && this.createScopedRequired() && url) {
       if (this.additionalClaims && (this.additionalClaims as {
@@ -167,7 +167,7 @@ export class JWT extends OAuth2Client {
    * @param refreshToken ignored
    * @private
    */
-  async refreshToken(refreshToken?: string|null): Promise<GetTokenResponse> {
+  async refreshToken(refreshToken?: string): Promise<GetTokenResponse> {
     if (!this.gtoken) {
       this.gtoken = new GoogleToken({
         iss: this.email,
@@ -183,8 +183,8 @@ export class JWT extends OAuth2Client {
       access_token: token,
       token_type: 'Bearer',
       expiry_date: this.gtoken.expiresAt
-    };
-    return {res: null, tokens};
+    } as Credentials;
+    return {tokens};
   }
 
   /**

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -26,9 +26,8 @@ export interface UserRefreshClientOptions extends RefreshOptions {
 
 export class UserRefreshClient extends OAuth2Client {
   // TODO: refactor tests to make this private
-  // In a future gts release, the _propertyName rule will be lifted.
   // This is also a hard one because `this.refreshToken` is a function.
-  _refreshToken?: string|null;
+  _refreshToken?: string;
 
   /**
    * User Refresh Token credentials.
@@ -65,8 +64,8 @@ export class UserRefreshClient extends OAuth2Client {
    * @param refreshToken An ignored refreshToken..
    * @param callback Optional callback.
    */
-  protected async refreshToken(refreshToken?: string|
-                               null): Promise<GetTokenResponse> {
+  protected async refreshToken(refreshToken?: string):
+      Promise<GetTokenResponse> {
     return super.refreshToken(this._refreshToken);
   }
 

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -31,7 +31,7 @@ export interface Transporter {
 export interface BodyResponseCallback<T> {
   // The `body` object is a truly dynamic type.  It must be `any`.
   // tslint:disable-next-line no-any
-  (err: Error|null, res?: AxiosResponse<T>|null): void;
+  (err: Error|null, res?: AxiosResponse<T>): void;
 }
 
 export interface RequestError extends AxiosError { errors: Error[]; }
@@ -105,7 +105,7 @@ export class DefaultTransporter {
   private processError(e: AxiosError): RequestError {
     const res = e.response;
     const err = e as RequestError;
-    const body = res ? res.data : null;
+    const body = res ? res.data : undefined;
     if (res && body && body.error && res.status !== 200) {
       if (typeof body.error === 'string') {
         err.message = body.error;

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -141,7 +141,7 @@ it('can obtain new access token when scopes are set', (done) => {
   const wantedToken = 'abc123';
   const want = 'Bearer ' + wantedToken;
   createGTokenMock({access_token: wantedToken});
-  jwt.getRequestMetadata(null, (err, result) => {
+  jwt.getRequestMetadata(undefined, (err, result) => {
     assert.strictEqual(null, err, 'no error was expected: got\n' + err);
     const got = result as {
       Authorization: string;
@@ -389,7 +389,7 @@ it('should return expiry_date in milliseconds', async () => {
   jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
   createGTokenMock({access_token: 'token', expires_in: 100});
-  const result = await jwt.refreshToken(null);
+  const result = await jwt.refreshToken();
   const creds = result.tokens;
   const dateInMillis = (new Date()).getTime();
   const expiryDate = new Date(creds.expiry_date!);

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -86,7 +86,7 @@ it('getRequestMetadata should not return cached tokens older than an hour',
    });
 
 it('createScopedRequired should return false', () => {
-  const client = new JWTAccess('foo@serviceaccount.com', null);
+  const client = new JWTAccess('foo@serviceaccount.com');
   assert.equal(false, client.createScopedRequired());
 });
 


### PR DESCRIPTION
BREAKING CHANGE:  Many methods that previously returned `null` may now return `undefined`. 

We had types that were optional or null all over the codebase.  Cleaned this up by removing any null type that was already optional. 