### PR TITLE
chore: cleanup iam interface

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -29,7 +29,6 @@ import {DefaultTransporter, Transporter} from '../transporters';
 import {Compute} from './computeclient';
 import {JWTInput} from './credentials';
 import {GCPEnv, getEnv} from './envDetect';
-import {IAMAuth, RequestMetadata} from './iam';
 import {JWTAccess} from './jwtaccess';
 import {JWT, JWTOptions} from './jwtclient';
 import {GetAccessTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';

--- a/src/auth/iam.ts
+++ b/src/auth/iam.ts
@@ -44,18 +44,12 @@ export class IAMAuth {
   }
 
   /**
-   * Pass the selector and token to the metadataFn callback.
-   *
-   * @param unused_uri is required of the credentials interface
-   * @param metadataFn a callback invoked with object
-   *                   containing request metadata.
+   * Acquire an object with the HTTP headers required for the request.
    */
-  getRequestMetadata(
-      unusedUri: string|null,
-      metadataFn: (err: Error|null, metadata?: RequestMetadata) => void) {
-    metadataFn(null, {
+  getRequestMetadata(): RequestMetadata {
+    return {
       'x-goog-iam-authority-selector': this.selector,
       'x-goog-iam-authorization-token': this.token
-    });
+    };
   }
 }

--- a/test/test.iam.ts
+++ b/test/test.iam.ts
@@ -15,17 +15,14 @@
  */
 
 import * as assert from 'assert';
-import {IAMAuth} from '../src/index';
+import {IAMAuth} from '../src';
 
-it('passes the token and selector to the callback ', done => {
+it('passes the token and selector to the callback ', () => {
   const testSelector = 'a-test-selector';
   const testToken = 'a-test-token';
   const client = new IAMAuth(testSelector, testToken);
-  client.getRequestMetadata(null, (err, creds) => {
-    assert.strictEqual(err, null, 'no error was expected: got\n' + err);
-    assert.notStrictEqual(creds, null, 'metadata should be present');
-    assert.strictEqual(creds!['x-goog-iam-authority-selector'], testSelector);
-    assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
-    done();
-  });
+  const creds = client.getRequestMetadata();
+  assert.notStrictEqual(creds, null, 'metadata should be present');
+  assert.strictEqual(creds!['x-goog-iam-authority-selector'], testSelector);
+  assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
 });


### PR DESCRIPTION
BREAKING CHANGE:  The `getRequestMetadata` of `IAMAuth` now directly returns http headers instead of requiring a callback function.

#### Old code

```js
IAMAuthClient.getRequestMetadata(null, (err, headers) => {
   console.log(headers);
});
```

#### New code

```js
const headers = IAMAuthClient.getRequestMetadata();
console.log(headers);
```