### PR TITLE
fix: don't duplicate user-agent

### DIFF
--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -19,6 +19,7 @@ import {validate} from './options';
 
 // tslint:disable-next-line no-var-requires
 const pkg = require('../../package.json');
+const PRODUCT_NAME = 'google-api-nodejs-client';
 
 export interface Transporter {
   request<T>(opts: AxiosRequestConfig): AxiosPromise<T>;
@@ -40,7 +41,7 @@ export class DefaultTransporter {
   /**
    * Default user agent.
    */
-  static readonly USER_AGENT = 'google-api-nodejs-client/' + pkg.version;
+  static readonly USER_AGENT = `${PRODUCT_NAME}/${pkg.version}`;
 
   /**
    * Configures request options before making a request.
@@ -53,7 +54,7 @@ export class DefaultTransporter {
     const uaValue: string = opts.headers['User-Agent'];
     if (!uaValue) {
       opts.headers['User-Agent'] = DefaultTransporter.USER_AGENT;
-    } else if (!uaValue.includes('google-api-nodejs-client/')) {
+    } else if (!uaValue.includes(`${PRODUCT_NAME}/`)) {
       opts.headers['User-Agent'] =
           `${uaValue} ${DefaultTransporter.USER_AGENT}`;
     }

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -50,13 +50,12 @@ export class DefaultTransporter {
   configure(opts: AxiosRequestConfig = {}): AxiosRequestConfig {
     // set transporter user agent
     opts.headers = opts.headers || {};
-    if (!opts.headers['User-Agent']) {
+    const uaValue: string = opts.headers['User-Agent'];
+    if (!uaValue) {
       opts.headers['User-Agent'] = DefaultTransporter.USER_AGENT;
-    } else if (
-        opts.headers['User-Agent'].indexOf(DefaultTransporter.USER_AGENT) ===
-        -1) {
+    } else if (!uaValue.includes('google-api-nodejs-client/')) {
       opts.headers['User-Agent'] =
-          opts.headers['User-Agent'] + ' ' + DefaultTransporter.USER_AGENT;
+          `${uaValue} ${DefaultTransporter.USER_AGENT}`;
     }
     return opts;
   }

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -49,8 +49,7 @@ it('should append default client user agent to the existing user agent', () => {
 
 it('should not append default client user agent to the existing user agent more than once',
    () => {
-     const appName =
-         'MyTestApplication-1.0 google-api-nodejs-client/' + version;
+     const appName = 'MyTestApplication-1.0 google-api-nodejs-client/foobear';
      const opts =
          transporter.configure({headers: {'User-Agent': appName}, url: ''});
      assert.equal(opts.headers!['User-Agent'], appName);


### PR DESCRIPTION
When deciding if we should add the google api user agent we were checking both the name *and* the value. In reality, we shouldn't duplicate the user-agent if the name matches, and the value doesn't. 