### PR TITLE
fix: ensure GCF can read metadata requests

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -631,6 +631,9 @@ export class GoogleAuth {
     }
 
     // For GCE, return the service account details from the metadata server
+    // NOTE: The trailing '/' at the end of service-accounts/ is very important!
+    // The GCF metadata server doesn't respect querystring params if this / is
+    // not included.
     const {data} = await gcpMetadata.instance(
         {property: 'service-accounts/', params: {recursive: true}});
 

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -632,7 +632,7 @@ export class GoogleAuth {
 
     // For GCE, return the service account details from the metadata server
     const {data} = await gcpMetadata.instance(
-        {property: 'service-accounts', params: {recursive: true}});
+        {property: 'service-accounts/', params: {recursive: true}});
 
     if (!data || !data.default || !data.default.email) {
       throw new Error('Failure from metadata server.');

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -31,7 +31,7 @@ nock.disableNetConnect();
 const tokenPath = `${BASE_PATH}/instance/service-accounts/default/token`;
 const host = HOST_ADDRESS;
 const instancePath = `${BASE_PATH}/instance`;
-const svcAccountPath = `${instancePath}/service-accounts?recursive=true`;
+const svcAccountPath = `${instancePath}/service-accounts/?recursive=true`;
 const API_KEY = 'test-123';
 const STUB_PROJECT = 'my-awesome-project';
 const ENDPOINT = '/events:report';


### PR DESCRIPTION
Resolves #321 

Turns out that the GCE metadata server isn't picky about the trailing slash, but GCF is 🤷‍♂️ 