### PR TITLE
fix: use id_token for IAP requests

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -27,6 +27,7 @@ export interface CredentialRequest {
   access_token?: string;
   token_type?: string;
   expires_in?: number;
+  id_token?: string;
 }
 
 export interface JWTInput {

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -103,7 +103,7 @@ export class JWT extends OAuth2Client {
                                      target_audience: string
                                    }).target_audience) {
         const {tokens} = await this.refreshToken();
-        return {headers: {Authorization: `Bearer ${tokens.access_token}`}};
+        return {headers: {Authorization: `Bearer ${tokens.id_token}`}};
       } else {
         // no scopes have been set, but a uri has been provided. Use JWTAccess
         // credentials.
@@ -174,7 +174,9 @@ export class JWT extends OAuth2Client {
     const tokens = {
       access_token: token,
       token_type: 'Bearer',
-      expiry_date: gtoken.expiresAt
+      expiry_date: gtoken.expiresAt,
+      // tslint:disable-next-line no-any
+      id_token: (gtoken.rawToken! as any).id_token
     };
     return {res: null, tokens};
   }

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -217,8 +217,9 @@ it('should accept additionalClaims that include a target_audience',
      jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
      const testUri = 'http:/example.com/my_test_service';
-     createGTokenMock({access_token: 'abc123'});
+     const scope = createGTokenMock({id_token: 'abc123'});
      const {headers} = await jwt.getRequestMetadata(testUri);
+     scope.done();
      const got = headers as {
        Authorization: string;
      };


### PR DESCRIPTION
This fixes an issue where we look at the access_token instead of the id_token for IAP based requests.  The `any` will be resolved when https://github.com/google/node-gtoken/pull/59 lands. 

Resolves #327 