### PR TITLE
feat: add getTokenInfo method

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ const tokens = await oauth2Client.refreshAccessToken();
 // store these new tokens in a safe place (e.g. database)
 ```
 
+##### Checking access_token information
+After obtaining and storing an access_token, at a later time you may want to go check the expiration date,
+original scopes, or audience for the token.  To get the token info, you can use the `getTokenInfo` method:
+
+```js
+// after acquiring an oAuth2Client...
+const tokenInfo = await oAuth2client.getTokenInfo('my-access-token');
+
+// take a look at the scopes originally provisioned for the access token
+console.log(tokenInfo.scopes);
+```
+
+This method will throw if the token is invalid.
+
 ##### OAuth2 with Installed Apps (Electron)
 If you're authenticating with OAuth2 from an installed application (like Electron), you may not want to embed your `client_secret` inside of the application sources. To work around this restriction, you can choose the `iOS` application type when creating your OAuth2 credentials in the [Google Developers console][devconsole]:
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ const tokens = await oauth2Client.refreshAccessToken();
 // store these new tokens in a safe place (e.g. database)
 ```
 
-##### Checking access_token information
-After obtaining and storing an access_token, at a later time you may want to go check the expiration date,
+##### Checking `access_token` information
+After obtaining and storing an `access_token`, at a later time you may want to go check the expiration date,
 original scopes, or audience for the token.  To get the token info, you can use the `getTokenInfo` method:
 
 ```js

--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -37,8 +37,8 @@ async function main() {
 
   // After acquiring an access_token, you may want to check on the audience, expiration,
   // or original scopes requested.  You can do that with the `getTokenInfo` method.
-  const info = await client.getTokenInfo(client.credentials.access_token);
-  console.log(info);
+  const tokenInfo = await client.getTokenInfo(client.credentials.access_token);
+  console.log(tokenInfo);
 }
 
 main().catch(console.error);

--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -31,10 +31,14 @@ async function main() {
     key: keys.private_key,
     scopes: ['https://www.googleapis.com/auth/cloud-platform']
   });
-  await client.authorize();
   const url = `https://www.googleapis.com/dns/v1/projects/${keys.project_id}`;
   const res = await client.request({ url });
   console.log(res.data);
+
+  // After acquiring an access_token, you may want to check on the audience, expiration,
+  // or original scopes requested.  You can do that with the `getTokenInfo` method.
+  const info = await client.getTokenInfo(client.credentials.access_token);
+  console.log(info);
 }
 
 main().catch(console.error);

--- a/examples/oauth2.js
+++ b/examples/oauth2.js
@@ -33,6 +33,13 @@ async function main() {
     const url = 'https://www.googleapis.com/plus/v1/people?query=pizza';
     const res = await oAuth2Client.request({ url });
     console.log(res.data);
+
+    // After acquiring an access_token, you may want to check on the audience, expiration,
+    // or original scopes requested.  You can do that with the `getTokenInfo` method.
+    const tokenInfo = await oAuth2Client.getTokenInfo(
+      oAuth2Client.credentials.access_token
+    );
+    console.log(tokenInfo);
   } catch (e) {
     console.error(e);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-auth-library",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -133,9 +133,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ZS0vBV7Jn5Z/Q4T3VXauEKMDCV8nWOtJJg90OsDylkYJiQwcWtKuLzohWzrthBkerUF7DLMmJcwOPEP0i/AOXw==",
       "dev": true
     },
     "@types/ncp": {
@@ -1038,6 +1038,15 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
     },
     "fs-extra": {
       "version": "5.0.0",
@@ -4233,40 +4242,34 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
-      "integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.0.tgz",
+      "integrity": "sha512-dMX7ZB2E1iQ5DOEOePoNJQp03uyhdMfb+kLXlNPbquv2FwfezD+0GbbHSgCw4MFhpSSS9NMoYJfOPMjCMJtXWA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
         "diff": "3.4.0",
+        "formatio": "1.2.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.2",
         "nise": "1.2.5",
-        "supports-color": "5.2.0",
+        "supports-color": "4.5.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "2.0.0"
           }
-        },
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-          "dev": true
         }
       }
     },

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -99,10 +99,10 @@ export interface TokenInfoRequest {
   user_id?: string;
   scope: string;
   expires_in: number;
-  azp: string;
-  sub: string;
-  exp: string;
-  access_type: string;
+  azp?: string;
+  sub?: string;
+  exp?: number;
+  access_type?: string;
 }
 
 export interface GenerateAuthUrlOpts {

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -36,6 +36,75 @@ export interface GetTokenOptions {
   codeVerifier?: string;
 }
 
+export interface TokenInfo {
+  /**
+   * The application that is the intended user of the access token.
+   */
+  aud: string;
+
+  /**
+   * This value lets you correlate profile information from multiple Google
+   * APIs. It is only present in the response if you included the profile scope
+   * in your request in step 1. The field value is an immutable identifier for
+   * the logged-in user that can be used to create and manage user sessions in
+   * your application. The identifier is the same regardless of which client ID
+   * is used to retrieve it. This enables multiple applications in the same
+   * organization to correlate profile information.
+   */
+  user_id?: string;
+
+  /**
+   * An array of scopes that the user granted access to.
+   */
+  scopes: string[];
+
+  /**
+   * The datetime when the token becomes invalid.
+   */
+  expiry_date: number;
+
+  /**
+   * An identifier for the user, unique among all Google accounts and never
+   * reused. A Google account can have multiple emails at different points in
+   * time, but the sub value is never changed. Use sub within your application
+   * as the unique-identifier key for the user.
+   */
+  sub?: string;
+
+  /**
+   * The client_id of the authorized presenter. This claim is only needed when
+   * the party requesting the ID token is not the same as the audience of the ID
+   * token. This may be the case at Google for hybrid apps where a web
+   * application and Android app have a different client_id but share the same
+   * project.
+   */
+  azp?: string;
+
+  /**
+   * Indicates whether your application can refresh access tokens
+   * when the user is not present at the browser. Valid parameter values are
+   * 'online', which is the default value, and 'offline'. Set the value to
+   * 'offline' if your application needs to refresh access tokens when the user
+   * is not present at the browser. This value instructs the Google
+   * authorization server to return a refresh token and an access token the
+   * first time that your application exchanges an authorization code for
+   * tokens.
+   */
+  access_type?: string;
+}
+
+
+export interface TokenInfoRequest {
+  aud: string;
+  user_id?: string;
+  scope: string;
+  expires_in: number;
+  azp: string;
+  sub: string;
+  exp: string;
+  access_type: string;
+}
+
 export interface GenerateAuthUrlOpts {
   /**
    * Recommended. Indicates whether your application can refresh access tokens
@@ -287,6 +356,9 @@ export class OAuth2Client extends AuthClient {
     this.eagerRefreshThresholdMillis =
         opts.eagerRefreshThresholdMillis || 5 * 60 * 1000;
   }
+
+  protected static readonly GOOGLE_TOKEN_INFO_URL =
+      'https://www.googleapis.com/oauth2/v3/tokeninfo';
 
   /**
    * The base URL for auth endpoints.
@@ -750,6 +822,30 @@ export class OAuth2Client extends AuthClient {
         OAuth2Client.ISSUERS_, options.maxExpiry);
 
     return login;
+  }
+
+  /**
+   * Obtains information about the provisioned access token.  Especially useful
+   * if you want to check the scopes that were provisioned to a given token.
+   *
+   * @param accessToken Required.  The Access Token for which you want to get
+   * user info.
+   */
+  async getTokenInfo(accessToken: string): Promise<TokenInfo> {
+    const {data} = await this.transporter.request<TokenInfoRequest>({
+      method: 'GET',
+      url: OAuth2Client.GOOGLE_TOKEN_INFO_URL,
+      params: {access_token: accessToken}
+    });
+    const info = Object.assign(
+        {
+          expiry_date: ((new Date()).getTime() + (data.expires_in * 1000)),
+          scopes: data.scope.split(' ')
+        },
+        data);
+    delete info.expires_in;
+    delete info.scope;
+    return info;
   }
 
   /**

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -940,3 +940,23 @@ it('should accept custom authBaseUrl and tokenUrl', async () => {
   const result = await client.getToken('12345');
   scope.done();
 });
+
+it('should obtain token info', async () => {
+  const accessToken = 'abc';
+  const tokenInfo = {
+    aud: 'naudience',
+    user_id: '12345',
+    scope: 'scope1 scope2',
+    expires_in: 1234
+  };
+
+  const scope = nock('https://www.googleapis.com')
+                    .get(`/oauth2/v3/tokeninfo?access_token=${accessToken}`)
+                    .reply(200, tokenInfo);
+
+  const info = await client.getTokenInfo(accessToken);
+  scope.done();
+  assert.equal(info.aud, tokenInfo.aud);
+  assert.equal(info.user_id, tokenInfo.user_id);
+  assert.deepEqual(info.scopes, tokenInfo.scope.split(' '));
+});


### PR DESCRIPTION
This adds a new `getTokenInfo` method to `OAuth2Client`, which calls the tokeninfo endpoint described here:
https://developers.google.com/identity/protocols/OAuth2UserAgent#validate-access-token

Resolves #336.