### PR TITLE
feat: emit an event when new tokens are obtained

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,24 @@ function getAuthenticatedClient() {
 main();
 ```
 
-##### IMPORTANT NOTE
-`refresh_token` is only returned on the first authorization.
- More details [here](https://github.com/google/google-api-nodejs-client/issues/750#issuecomment-304521450)
+##### Handling token events
+This library will automatically obtain an `access_token`, and automatically refresh the `access_token` if a `refresh_token` is present.  The `refresh_token` is only returned on the [first authorization]((https://github.com/google/google-api-nodejs-client/issues/750#issuecomment-304521450), so if you want to make sure you store it safely. An easy way to make sure you always store the most recent tokens is to use the `tokens` event:
 
+```js
+const client = await auth.getClient();
+
+client.on('tokens', (tokens) => {
+  if (tokens.refresh_token) {
+    // store the refresh_token in my database!
+    console.log(tokens.refresh_token);
+  }
+  console.log(tokens.access_token);
+});
+
+const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
+const res = await client.request({ url });
+// The `tokens` event would now be raised if this was the first request
+```
 
 ##### Retrieve access token
 With the code returned, you can ask for an access token as shown below:

--- a/src/auth/authclient.ts
+++ b/src/auth/authclient.ts
@@ -15,10 +15,17 @@
  */
 
 import {AxiosPromise, AxiosRequestConfig} from 'axios';
+import {EventEmitter} from 'events';
+
 import {DefaultTransporter} from '../transporters';
+
 import {Credentials} from './credentials';
 
-export abstract class AuthClient {
+export declare interface AuthClient {
+  on(event: 'tokens', listener: (tokens: Credentials) => void): this;
+}
+
+export abstract class AuthClient extends EventEmitter {
   transporter = new DefaultTransporter();
   credentials: Credentials = {};
 

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -86,6 +86,7 @@ export class Compute extends OAuth2Client {
           ((new Date()).getTime() + (res.data.expires_in * 1000));
       delete (tokens as CredentialRequest).expires_in;
     }
+    this.emit('tokens', tokens);
     return {tokens, res};
   }
 

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -179,6 +179,7 @@ export class JWT extends OAuth2Client {
       // tslint:disable-next-line no-any
       id_token: (gtoken.rawToken! as any).id_token
     };
+    this.emit('tokens', tokens);
     return {res: null, tokens};
   }
 

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -494,6 +494,7 @@ export class OAuth2Client extends AuthClient {
           ((new Date()).getTime() + (res.data.expires_in * 1000));
       delete (tokens as CredentialRequest).expires_in;
     }
+    this.emit('tokens', tokens);
     return {tokens, res};
   }
 
@@ -551,6 +552,9 @@ export class OAuth2Client extends AuthClient {
           ((new Date()).getTime() + (res.data.expires_in * 1000));
       delete (tokens as CredentialRequest).expires_in;
     }
+
+    this.emit('tokens', tokens);
+
     return {tokens, res};
   }
 

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -552,9 +552,7 @@ export class OAuth2Client extends AuthClient {
           ((new Date()).getTime() + (res.data.expires_in * 1000));
       delete (tokens as CredentialRequest).expires_in;
     }
-
     this.emit('tokens', tokens);
-
     return {tokens, res};
   }
 

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -69,6 +69,19 @@ it('should refresh if access token has expired', async () => {
   scopes.forEach(s => s.done());
 });
 
+it('should emit an event for a new access token', async () => {
+  const scopes = [mockToken(), mockExample()];
+  let raisedEvent = false;
+  compute.on('tokens', tokens => {
+    assert.equal(tokens.access_token, 'abc123');
+    raisedEvent = true;
+  });
+  await compute.request({url});
+  assert.equal(compute.credentials.access_token, 'abc123');
+  scopes.forEach(s => s.done());
+  assert(raisedEvent);
+});
+
 it('should refresh if access token will expired soon and time to refresh before expiration is set',
    async () => {
      const scopes = [mockToken(), mockExample()];

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -133,28 +133,20 @@ it('can get obtain new access token when scopes are set', (done) => {
   });
 });
 
-
 it('should emit an event for tokens', (done) => {
+  const accessToken = 'initial-access-token';
+  const scope = createGTokenMock({access_token: accessToken});
   const jwt = new JWT({
     email: 'foo@serviceaccount.com',
     keyFile: PEM_PATH,
     scopes: ['http://bar', 'http://foo'],
     subject: 'bar@subjectaccount.com'
   });
-
-  let raisedEvent = false;
   jwt.on('tokens', tokens => {
-    assert.equal(tokens.access_token, 'initial-access-token');
-    raisedEvent = true;
-  });
-
-  jwt.credentials = {refresh_token: 'jwt-placeholder'};
-  const scope = createGTokenMock({access_token: 'initial-access-token'});
-  jwt.getAccessToken((err, got) => {
-    scope.done();
-    assert(raisedEvent);
-    done();
-  });
+       assert.equal(tokens.access_token, accessToken);
+       scope.done();
+       done();
+     }).getAccessToken();
 });
 
 it('can obtain new access token when scopes are set', (done) => {

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -130,6 +130,30 @@ it('can get obtain new access token when scopes are set', (done) => {
   });
 });
 
+
+it('should emit an event for tokens', (done) => {
+  const jwt = new JWT({
+    email: 'foo@serviceaccount.com',
+    keyFile: PEM_PATH,
+    scopes: ['http://bar', 'http://foo'],
+    subject: 'bar@subjectaccount.com'
+  });
+
+  let raisedEvent = false;
+  jwt.on('tokens', tokens => {
+    assert.equal(tokens.access_token, 'initial-access-token');
+    raisedEvent = true;
+  });
+
+  jwt.credentials = {refresh_token: 'jwt-placeholder'};
+  const scope = createGTokenMock({access_token: 'initial-access-token'});
+  jwt.getAccessToken((err, got) => {
+    scope.done();
+    assert(raisedEvent);
+    done();
+  });
+});
+
 it('can obtain new access token when scopes are set', (done) => {
   const jwt = new JWT({
     email: 'foo@serviceaccount.com',
@@ -153,6 +177,8 @@ it('can obtain new access token when scopes are set', (done) => {
     done();
   });
 });
+
+
 
 it('gets a jwt header access token', (done) => {
   const keys = keypair(1024 /* bitsize of private key */);

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -736,9 +736,19 @@ function mockExample() {
 
 it('should refresh token if missing access token', (done) => {
   const scopes = mockExample();
-  client.credentials = {refresh_token: 'refresh-token-placeholder'};
+  let raisedEvent = false;
+  const refreshToken = 'refresh-token-placeholder';
+  client.credentials = {refresh_token: refreshToken};
+
+  // ensure the tokens event is raised
+  client.on('tokens', tokens => {
+    assert.equal(tokens.access_token, 'abc123');
+    raisedEvent = true;
+  });
+
   client.request({url: 'http://example.com'}, err => {
     scopes.forEach(s => s.done());
+    assert(raisedEvent);
     assert.equal('abc123', client.credentials.access_token);
     done();
   });

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -736,20 +736,21 @@ function mockExample() {
 
 it('should refresh token if missing access token', (done) => {
   const scopes = mockExample();
+  const accessToken = 'abc123';
   let raisedEvent = false;
   const refreshToken = 'refresh-token-placeholder';
   client.credentials = {refresh_token: refreshToken};
 
   // ensure the tokens event is raised
   client.on('tokens', tokens => {
-    assert.equal(tokens.access_token, 'abc123');
+    assert.equal(tokens.access_token, accessToken);
     raisedEvent = true;
   });
 
   client.request({url: 'http://example.com'}, err => {
     scopes.forEach(s => s.done());
     assert(raisedEvent);
-    assert.equal('abc123', client.credentials.access_token);
+    assert.equal(accessToken, client.credentials.access_token);
     done();
   });
 });


### PR DESCRIPTION
Today we really have no way to tell users when their access_token was refreshed.  Some people store these on the server across multiple requests, so giving them some way to know when it happens would be nice.  Users are asking for this over in google-api-nodejs-client.  

Resolves #340.