### PR TITLE
feat: export additional types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
 import {GoogleAuth} from './auth/googleauth';
 
 export {Compute} from './auth/computeclient';
+export {GoogleAuthOptions} from './auth/googleauth';
 export {IAMAuth} from './auth/iam';
 export {JWTAccess} from './auth/jwtaccess';
 export {JWT} from './auth/jwtclient';

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -14,15 +14,26 @@
  * limitations under the License.
  */
 import * as assert from 'assert';
-
-import {DefaultTransporter, GoogleAuth} from '../src';
+import * as gal from '../src';
 
 it('should publicly export GoogleAuth', () => {
   const cjs = require('../src/');
-  assert.strictEqual(cjs.GoogleAuth, GoogleAuth);
+  assert.strictEqual(cjs.GoogleAuth, gal.GoogleAuth);
 });
 
 it('should publicly export DefaultTransporter', () => {
   const cjs = require('../src');
-  assert.strictEqual(cjs.DefaultTransporter, DefaultTransporter);
+  assert.strictEqual(cjs.DefaultTransporter, gal.DefaultTransporter);
+});
+
+it('should export all the things', () => {
+  assert(gal.CodeChallengeMethod);
+  assert(gal.Compute);
+  assert(gal.DefaultTransporter);
+  assert(gal.IAMAuth);
+  assert(gal.JWT);
+  assert(gal.JWTAccess);
+  assert(gal.OAuth2Client);
+  assert(gal.UserRefreshClient);
+  assert(gal.GoogleAuth);
 });


### PR DESCRIPTION
As I started integrating this into other google-cloud libraries, I found that I needed the `GoogleAuthOptions` type in a few places.  Exporting to make it easier to use. 