### PR TITLE
feat: add auth.request method

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AxiosError} from 'axios';
+import {AxiosError, AxiosRequestConfig, AxiosResponse} from 'axios';
 import {exec} from 'child_process';
 import * as fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';
@@ -701,6 +701,16 @@ export class GoogleAuth {
     const {headers} = await client.getRequestMetadata(url);
     opts.headers = Object.assign(opts.headers || {}, headers);
     return opts;
+  }
+
+  /**
+   * Automatically obtain application default credentials, and make an
+   * HTTP request using the given options.
+   * @param opts Axios request options for the HTTP request.
+   */
+  async request(opts: AxiosRequestConfig): Promise<AxiosResponse> {
+    const client = await this.getClient();
+    return client.request(opts);
   }
 
   /**

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1295,3 +1295,14 @@ it('should get the current environment if GAE', async () => {
   const env = await auth.getEnv();
   assert.equal(env, envDetect.GCPEnv.APP_ENGINE);
 });
+
+it('should make the request', async () => {
+  const url = 'http://example.com';
+  const {auth, scopes} = mockGCE();
+  const data = {breakfast: 'coffee'};
+  const scope = nock(url).get('/').reply(200, data);
+  scopes.push(scope);
+  const res = await auth.request({url});
+  scopes.forEach(s => s.done());
+  assert.deepEqual(res.data, data);
+});


### PR DESCRIPTION
Another one that come up while trying to swap out google-auto-auth.  This way consumers can make a single call to get the client and make the request, with client caching. 