### PR TITLE
Allow redirect_uri and client_id overrides in getToken opts

### DIFF
--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -34,6 +34,19 @@ export enum CodeChallengeMethod {
 export interface GetTokenOptions {
   code: string;
   codeVerifier?: string;
+  /**
+   * The client ID for your application. The value passed into the constructor
+   * will be used if not provided. Must match any client_id option passed to
+   * a corresponding call to generateAuthUrl.
+   */
+  client_id?: string;
+  /**
+   * Determines where the API server redirects the user after the user
+   * completes the authorization flow. The value passed into the constructor
+   * will be used if not provided. Must match any redirect_uri option passed to
+   * a corresponding call to generateAuthUrl.
+   */
+  redirect_uri?: string;
 }
 
 export interface TokenInfo {
@@ -476,9 +489,9 @@ export class OAuth2Client extends AuthClient {
     const url = this.tokenUrl || OAuth2Client.GOOGLE_OAUTH2_TOKEN_URL_;
     const values = {
       code: options.code,
-      client_id: this._clientId,
+      client_id: options.client_id || this._clientId,
       client_secret: this._clientSecret,
-      redirect_uri: this.redirectUri,
+      redirect_uri: options.redirect_uri || this.redirectUri,
       grant_type: 'authorization_code',
       code_verifier: options.codeVerifier
     };

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -982,6 +982,72 @@ it('getToken should allow a code_verifier to be passed', async () => {
   assert(params.code_verifier === 'its_verified');
 });
 
+it('getToken should set redirect_uri if not provided in options', async () => {
+  const scope =
+      nock(baseUrl)
+          .post('/oauth2/v4/token', undefined, {
+            reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
+          })
+          .reply(
+              200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
+  const res = await client.getToken({code: 'code here'});
+  scope.done();
+  assert(res.res);
+  if (!res.res) return;
+  const params = qs.parse(res.res.config.data);
+  assert.equal(params.redirect_uri, REDIRECT_URI);
+});
+
+it('getToken should set client_id if not provided in options', async () => {
+  const scope =
+      nock(baseUrl)
+          .post('/oauth2/v4/token', undefined, {
+            reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
+          })
+          .reply(
+              200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
+  const res = await client.getToken({code: 'code here'});
+  scope.done();
+  assert(res.res);
+  if (!res.res) return;
+  const params = qs.parse(res.res.config.data);
+  assert.equal(params.client_id, CLIENT_ID);
+});
+
+it('getToken should override redirect_uri if provided in options', async () => {
+  const scope =
+      nock(baseUrl)
+          .post('/oauth2/v4/token', undefined, {
+            reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
+          })
+          .reply(
+              200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
+  const res =
+      await client.getToken({code: 'code here', redirect_uri: 'overridden'});
+  scope.done();
+  assert(res.res);
+  if (!res.res) return;
+  const params = qs.parse(res.res.config.data);
+  assert.equal(params.redirect_uri, 'overridden');
+});
+
+it('getToken should override client_id if provided in options', async () => {
+  const scope =
+      nock(baseUrl)
+          .post('/oauth2/v4/token', undefined, {
+            reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}
+          })
+          .reply(
+              200, {access_token: 'abc', refresh_token: '123', expires_in: 10});
+  const res =
+      await client.getToken({code: 'code here', client_id: 'overridden'});
+  scope.done();
+  assert(res.res);
+  if (!res.res) return;
+  const params = qs.parse(res.res.config.data);
+  assert.equal(params.client_id, 'overridden');
+});
+
 it('should return expiry_date', done => {
   const now = (new Date()).getTime();
   const scope =


### PR DESCRIPTION
The current `generateAuthUrl()` implementation allows for the `redirect_uri` opt to be overridden. Without the ability to specify the same override in the corresponding call to `getToken()`, the code exchange endpoint returns an error indicating a mismatch.

This change allows the `redirect_uri` and `client_id` used in the subsequent call to `getToken()` (and passed to the code exchange endpoint) to similarly be overridden.

A `redirect_uri` use case is straightforward, where a command line application (such as [clasp](https://github.com/google/clasp)) may wish to provide a localhost webserver to process the credentials returned from the code exchange endpoint, where the uri will contain a port number that was not known at the time the corresponding OAuth2Client was constructed. One current workaround is to re-assign the OAuth2Client.redirectUri private property. Another workaround is to re-construct the corresponding OAuth2Client object. 

While I know of no similar explicit use case for overriding the client_id, this change also addresses whatever the original use case was for overriding the client_id in the corresponding call to generateAuthUrl().