### PR TITLE
fix: read credentials field before keyFilename

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -657,12 +657,12 @@ export class GoogleAuth {
       this.jsonContent = options.credentials || this.jsonContent;
     }
     if (!this.cachedCredential) {
-      if (this.keyFilename) {
+      if (this.jsonContent) {
+        this.cachedCredential = await this.fromJSON(this.jsonContent);
+      } else if (this.keyFilename) {
         const filePath = path.resolve(this.keyFilename);
         const stream = fs.createReadStream(filePath);
         this.cachedCredential = await this.fromStreamAsync(stream);
-      } else if (this.jsonContent) {
-        this.cachedCredential = await this.fromJSON(this.jsonContent);
       } else {
         await this.getApplicationDefaultAsync();
       }

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -23,7 +23,8 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as stream from 'stream';
 
-import {GoogleAuth, JWT, UserRefreshClient} from '../src';
+import {GoogleAuth, GoogleAuthOptions, JWT, UserRefreshClient} from '../src';
+import {CredentialBody} from '../src/auth/credentials';
 import * as envDetect from '../src/auth/envDetect';
 
 nock.disableNetConnect();
@@ -1227,6 +1228,16 @@ it('should accept credentials to get a client', async () => {
   const auth = new GoogleAuth({credentials});
   const client = await auth.getClient() as JWT;
   assert.equal(client.email, 'hello@youarecool.com');
+});
+
+it('should prefer credentials over keyFilename', async () => {
+  const credentials: CredentialBody = Object.assign(
+      require('../../test/fixtures/private.json'),
+      {client_email: 'hello@butiamcooler.com'});
+  const auth = new GoogleAuth(
+      {credentials, keyFilename: './test/fixtures/private.json'});
+  const client = await auth.getClient() as JWT;
+  assert.equal(client.email, credentials.client_email);
 });
 
 it('should allow passing scopes to get a client', async () => {


### PR DESCRIPTION
In `google-auto-auth`, [credentials were being read before keyFilename](https://github.com/stephenplusplus/google-auto-auth/blob/master/index.js#L103).

I think in porting over features, that order was switched, so this PR switches it back.