### PR TITLE
feat: add sign method to JWT

### DIFF
--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -748,11 +748,10 @@ export class GoogleAuth {
       throw new Error('Cannot sign data without `client_email`.');
     }
 
-    const idString =
-        `projects/${projectId}/serviceAccounts/${creds.client_email}`;
+    const id = `projects/${projectId}/serviceAccounts/${creds.client_email}`;
     const res = await this.request<SignBlobResponse>({
       method: 'POST',
-      url: `https://iam.googleapis.com/v1/${idString}:signBlob`,
+      url: `https://iam.googleapis.com/v1/${id}:signBlob`,
       data: {bytesToSign: Buffer.from(data).toString('base64')}
     });
     return res.data.signature;

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -16,6 +16,7 @@
 
 import {AxiosError, AxiosRequestConfig, AxiosResponse} from 'axios';
 import {exec} from 'child_process';
+import crypto from 'crypto';
 import fs from 'fs';
 import * as gcpMetadata from 'gcp-metadata';
 import http from 'http';
@@ -723,4 +724,41 @@ export class GoogleAuth {
   getEnv(): Promise<GCPEnv> {
     return getEnv();
   }
+
+  /**
+   * Sign the given data with the current private key, or go out
+   * to the IAM API to sign it.
+   * @param data The data to be signed.
+   */
+  async sign(data: string): Promise<string> {
+    const client = await this.getClient();
+    if (client instanceof JWT && client.key) {
+      const sign = crypto.createSign('RSA-SHA256');
+      sign.update(data);
+      return sign.sign(client.key, 'base64');
+    }
+
+    const projectId = await this.getProjectId();
+    if (!projectId) {
+      throw new Error('Cannot sign data without a project ID.');
+    }
+
+    const creds = await this.getCredentials();
+    if (!creds.client_email) {
+      throw new Error('Cannot sign data without `client_email`.');
+    }
+
+    const idString =
+        `projects/${projectId}/serviceAccounts/${creds.client_email}`;
+    const res = await this.request<SignBlobResponse>({
+      method: 'POST',
+      url: `https://iam.googleapis.com/v1/${idString}:signBlob`,
+      data: {bytesToSign: Buffer.from(data).toString('base64')}
+    });
+    return res.data.signature;
+  }
+}
+
+export interface SignBlobResponse {
+  signature: string;
 }

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -16,7 +16,6 @@
 
 import {GoogleToken} from 'gtoken';
 import stream from 'stream';
-import crypto from 'crypto';
 import {CredentialBody, Credentials, JWTInput} from './credentials';
 import {JWTAccess} from './jwtaccess';
 import {GetTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';
@@ -289,39 +288,4 @@ export class JWT extends OAuth2Client {
     }
     throw new Error('A key or a keyFile must be provided to getCredentials.');
   }
-
-  /**
-   * Sign the given data with the current private key, or go out
-   * to the IAM API to sign it.
-   * @param data The data to be signed.
-   */
-  async sign(data: string): Promise<string> {
-    if (this.key) {
-      const sign = crypto.createSign('RSA-SHA256');
-      sign.update(data);
-      return sign.sign(this.key, 'base64');
-    }
-
-    if (!this.projectId) {
-      throw new Error('Cannot sign data without a project ID.');
-    }
-
-    if (!this.email) {
-      throw new Error('Cannot sign data without `client_email`.');
-    }
-
-    const idString = `projects/${this.projectId}/serviceAccounts/${this.email}`;
-    const res = await this.request<SignBlobResponse>({
-      method: 'POST',
-      url: `https://iam.googleapis.com/v1/${idString}:signBlob`,
-      data: {
-        bytesToSign: Buffer.from(data).toString('base64')
-      }
-    });
-    return res.data.signature;
-  }
-}
-
-export interface SignBlobResponse {
-  signature: string;
 }

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -16,7 +16,7 @@
 
 import {GoogleToken} from 'gtoken';
 import stream from 'stream';
-
+import crypto from 'crypto';
 import {CredentialBody, Credentials, JWTInput} from './credentials';
 import {JWTAccess} from './jwtaccess';
 import {GetTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';
@@ -289,4 +289,39 @@ export class JWT extends OAuth2Client {
     }
     throw new Error('A key or a keyFile must be provided to getCredentials.');
   }
+
+  /**
+   * Sign the given data with the current private key, or go out
+   * to the IAM API to sign it.
+   * @param data The data to be signed.
+   */
+  async sign(data: string): Promise<string> {
+    if (this.key) {
+      const sign = crypto.createSign('RSA-SHA256');
+      sign.update(data);
+      return sign.sign(this.key, 'base64');
+    }
+
+    if (!this.projectId) {
+      throw new Error('Cannot sign data without a project ID.');
+    }
+
+    if (!this.email) {
+      throw new Error('Cannot sign data without `client_email`.');
+    }
+
+    const idString = `projects/${this.projectId}/serviceAccounts/${this.email}`;
+    const res = await this.request<SignBlobResponse>({
+      method: 'POST',
+      url: `https://iam.googleapis.com/v1/${idString}:signBlob`,
+      data: {
+        bytesToSign: Buffer.from(data).toString('base64')
+      }
+    });
+    return res.data.signature;
+  }
+}
+
+export interface SignBlobResponse {
+  signature: string;
 }


### PR DESCRIPTION
The idea is to replicate what's available [here](https://github.com/stephenplusplus/google-auto-auth/blob/master/index.js#L303).  It's used in nodejs-storage, and is blocking the integration of the new `nodejs-common` into `nodejs-storage`. 

@stephenplusplus I will admit that I don't entirely know what this is trying to do.  Can you walk us through the scenarios in how this is used?  
- Are you sure it belongs in the auth library, or does this belong in nodejs-common?
- Is this useful on anything *other* than a service account credential?  For example, does it make sense in the context of a Compute credential, or straight up OAuth2?

After we figure out where to stick this thing, I'll write tests 😆 

FYI @alexander-fenster @callmehiphop