### PR TITLE
chore: fix lint task in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ workflows:
           filters: *release_tags
       - node10:
           filters: *release_tags
+      - lint:
+          requires:
+            - node4
+            - node6
+            - node8
+            - node10
+          filters: *release_tags
       - publish_npm:
           requires:
             - node4
@@ -88,11 +95,6 @@ jobs:
         user: node
     <<: *unit_tests
   lint:
-    requires:
-      - node4
-      - node6
-      - node8
-      - node10
     docker:
       - image: node:10
         user: node


### PR DESCRIPTION
It never worked (wrong syntax, `requires` can be in workflow, not in a job description), but Circle never complained. Actually, it complained only when I tried to rerun something with SSH:

![image](https://user-images.githubusercontent.com/4015807/40944786-e0c92128-680a-11e8-9f3f-5faaa14dbfd9.png)
