### PR TITLE
feat: enable custom service account with compute client

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ const {Compute} = require('google-auth-library');
 async function main() {
   const client = new Compute({
     // Specifying the service account email is optional.
-    serviceAccountEmail: 'my@gserviceaccount.com'
+    serviceAccountEmail: 'my-service-account@example.com'
   });
   const projectId = 'your-project-id';
   const url = `https://www.googleapis.com/dns/v1/projects/${project_id}`;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The `1.x` release includes a variety of bug fixes, new features, and breaking ch
 This library provides a variety of ways to authenticate to your Google services.
 - [Application Default Credentials](#choosing-the-correct-credential-type-automatically) - Use Application Default Credentials when you use a single identity for all users in your application. Especially useful for applications running on Google Cloud.
 - [OAuth 2](#oauth2) - Use OAuth2 when you need to perform actions on behalf of the end user.
-- [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users.  Especially useful for server->server or server->API communication.
+- [JSON Web Tokens](#json-web-tokens) - Use JWT when you are using a single identity for all users. Especially useful for server->server or server->API communication.
+- [Google Compute](#compute) - Directly use a service account on Google Cloud Platform. Useful for server->server or server->API communication.
 
 ## Application Default Credentials
 This library provides an implementation of [Application Default Credentials][] for Node.js. The [Application Default Credentials][] provide a simple way to get authorization credentials for use in calling Google APIs.
@@ -269,7 +270,7 @@ const oAuth2Client = new OAuth2Client({
 The Google Developers Console provides a `.json` file that you can use to configure a JWT auth client and authenticate your requests, for example when using a service account.
 
 ``` js
-const {JWT} = require('../build/src/index');
+const {JWT} = require('google-auth-library');
 const keys = require('./jwt.keys.json');
 
 async function main() {
@@ -341,6 +342,30 @@ You can use the following environment variables to proxy HTTP and HTTPS requests
 - `HTTPS_PROXY` / `https_proxy`
 
 When HTTP_PROXY / http_proxy are set, they will be used to proxy non-SSL requests that do not have an explicit proxy configuration option present. Similarly, HTTPS_PROXY / https_proxy will be respected for SSL requests that do not have an explicit proxy configuration option. It is valid to define a proxy in one of the environment variables, but then override it for a specific request, using the proxy configuration option.
+
+
+## Compute
+If your application is running on Google Cloud Platform, you can authenticate using the default service account or by specifying a specific service account.
+
+**Note**: In most cases, you will want to use [Application Default Credentials](choosing-the-correct-credential-type-automatically).  Direct use of the `Compute` class is for very specific scenarios.
+
+``` js
+const {Compute} = require('google-auth-library');
+
+async function main() {
+  const client = new Compute({
+    // Specifying the service account email is optional.
+    serviceAccountEmail: 'my@gserviceaccount.com'
+  });
+  const projectId = 'your-project-id';
+  const url = `https://www.googleapis.com/dns/v1/projects/${project_id}`;
+  const res = await client.request({url});
+  console.log(res.data);
+}
+
+main().catch(console.error);
+
+```
 
 ## Questions/problems?
 

--- a/examples/compute.js
+++ b/examples/compute.js
@@ -1,0 +1,31 @@
+// Copyright 2018, Google, LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { Compute } = require('google-auth-library');
+
+/**
+ * Acquire a client, and make a request to an API that's enabled by default.
+ */
+async function main() {
+  const client = new Compute({
+    serviceAccountEmail: 'beckwith@google.com'
+  });
+  const projectId = 'el-gato';
+  const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;
+  const res = await client.request({ url });
+  console.log(res.data);
+}
+
+main().catch(console.error);

--- a/examples/compute.js
+++ b/examples/compute.js
@@ -20,7 +20,9 @@ const { Compute } = require('google-auth-library');
  */
 async function main() {
   const client = new Compute({
-    serviceAccountEmail: 'beckwith@google.com'
+    // Specifying the serviceAccountEmail is optional. It will use the default
+    // service account if one is not defined.
+    serviceAccountEmail: 'some-service-account@some-place.org'
   });
   const projectId = 'el-gato';
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;

--- a/examples/compute.js
+++ b/examples/compute.js
@@ -22,7 +22,7 @@ async function main() {
   const client = new Compute({
     // Specifying the serviceAccountEmail is optional. It will use the default
     // service account if one is not defined.
-    serviceAccountEmail: 'some-service-account@some-place.org'
+    serviceAccountEmail: 'some-service-account@example.com'
   });
   const projectId = 'el-gato';
   const url = `https://www.googleapis.com/dns/v1/projects/${projectId}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -22,7 +22,8 @@ import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
 export interface ComputeOptions extends RefreshOptions {
   /**
-   * The service account email to use, or 'default'. A Compute Engine instance may have multiple service accounts.
+   * The service account email to use, or 'default'. A Compute Engine instance
+   * may have multiple service accounts.
    */
   serviceAccountEmail?: string;
 }
@@ -32,7 +33,6 @@ const ax = axios.create();
 rax.attach(ax);
 
 export class Compute extends OAuth2Client {
-
   private serviceAccountEmail: string;
 
   /**
@@ -68,11 +68,14 @@ export class Compute extends OAuth2Client {
   protected async refreshTokenNoCache(refreshToken?: string|
                                       null): Promise<GetTokenResponse> {
     const url = this.tokenUrl ||
-        `${gcpMetadata.HOST_ADDRESS}${gcpMetadata.BASE_PATH}/instance/service-accounts/${this.serviceAccountEmail}/token`;
+        `${gcpMetadata.HOST_ADDRESS}${
+                    gcpMetadata.BASE_PATH}/instance/service-accounts/${
+                    this.serviceAccountEmail}/token`;
     let res: AxiosResponse<CredentialRequest>;
     // request for new token
     try {
-      // TODO: In 2.0, we should remove the ability to configure the tokenUrl, and switch this over to use the gcp-metadata package instead.
+      // TODO: In 2.0, we should remove the ability to configure the tokenUrl,
+      // and switch this over to use the gcp-metadata package instead.
       res = await ax.request<CredentialRequest>({
         url,
         headers: {[gcpMetadata.HEADER_NAME]: 'Google'},

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -20,18 +20,20 @@ import * as rax from 'retry-axios';
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
-export interface ComputeOptions extends RefreshOptions {}
+export interface ComputeOptions extends RefreshOptions {
+  /**
+   * The service account email to use, or 'default'. A Compute Engine instance may have multiple service accounts.
+   */
+  serviceAccountEmail?: string;
+}
 
 // Create a scoped axios instance that will retry 3 times by default
 const ax = axios.create();
 rax.attach(ax);
 
 export class Compute extends OAuth2Client {
-  /**
-   * Google Compute Engine metadata server token endpoint.
-   */
-  protected static readonly _GOOGLE_OAUTH2_TOKEN_URL =
-      `${gcpMetadata.BASE_PATH}/instance/service-accounts/default/token`;
+
+  private serviceAccountEmail: string;
 
   /**
    * Google Compute Engine service account credentials.
@@ -39,11 +41,12 @@ export class Compute extends OAuth2Client {
    * Retrieve access token from the metadata server.
    * See: https://developers.google.com/compute/docs/authentication
    */
-  constructor(options?: ComputeOptions) {
+  constructor(options: ComputeOptions = {}) {
     super(options);
     // Start with an expired refresh token, which will automatically be
     // refreshed before the first API call is made.
     this.credentials = {expiry_date: 1, refresh_token: 'compute-placeholder'};
+    this.serviceAccountEmail = options.serviceAccountEmail || 'default';
   }
 
   /**
@@ -65,12 +68,11 @@ export class Compute extends OAuth2Client {
   protected async refreshTokenNoCache(refreshToken?: string|
                                       null): Promise<GetTokenResponse> {
     const url = this.tokenUrl ||
-        `${gcpMetadata.HOST_ADDRESS}${Compute._GOOGLE_OAUTH2_TOKEN_URL}`;
-    let res: AxiosResponse<CredentialRequest>|null = null;
+        `${gcpMetadata.HOST_ADDRESS}${gcpMetadata.BASE_PATH}/instance/service-accounts/${this.serviceAccountEmail}/token`;
+    let res: AxiosResponse<CredentialRequest>;
     // request for new token
     try {
-      // TODO: In 2.0, we should remove the ability to configure the tokenUrl,
-      // and switch this over to use the gcp-metadata package instead.
+      // TODO: In 2.0, we should remove the ability to configure the tokenUrl, and switch this over to use the gcp-metadata package instead.
       res = await ax.request<CredentialRequest>({
         url,
         headers: {[gcpMetadata.HEADER_NAME]: 'Google'},

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -260,3 +260,18 @@ it('should return a helpful message on token refresh response.statusCode 404',
      }
      throw new Error('Expected to throw');
    });
+
+it('should accept a custom service account', async() => {
+  const serviceAccountEmail = 'beckwith@google.com';
+  const compute = new Compute({ serviceAccountEmail });
+  const scopes = [
+    mockExample(),
+    nock(HOST_ADDRESS).get(`${BASE_PATH}/instance/service-accounts/${serviceAccountEmail}/token`).reply(200, {
+      access_token: 'abc123',
+      expires_in: 10000
+    })
+  ];
+  await compute.request({url});
+  scopes.forEach(s => s.done());
+  assert.equal(compute.credentials.access_token, 'abc123');
+});

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -261,15 +261,15 @@ it('should return a helpful message on token refresh response.statusCode 404',
      throw new Error('Expected to throw');
    });
 
-it('should accept a custom service account', async() => {
+it('should accept a custom service account', async () => {
   const serviceAccountEmail = 'beckwith@google.com';
-  const compute = new Compute({ serviceAccountEmail });
+  const compute = new Compute({serviceAccountEmail});
   const scopes = [
     mockExample(),
-    nock(HOST_ADDRESS).get(`${BASE_PATH}/instance/service-accounts/${serviceAccountEmail}/token`).reply(200, {
-      access_token: 'abc123',
-      expires_in: 10000
-    })
+    nock(HOST_ADDRESS)
+        .get(`${BASE_PATH}/instance/service-accounts/${
+            serviceAccountEmail}/token`)
+        .reply(200, {access_token: 'abc123', expires_in: 10000})
   ];
   await compute.request({url});
   scopes.forEach(s => s.done());

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -262,7 +262,7 @@ it('should return a helpful message on token refresh response.statusCode 404',
    });
 
 it('should accept a custom service account', async () => {
-  const serviceAccountEmail = 'beckwith@google.com';
+  const serviceAccountEmail = 'service-account@example.com';
   const compute = new Compute({serviceAccountEmail});
   const scopes = [
     mockExample(),


### PR DESCRIPTION
This adds the ability to specify which service account the developer wants to use when using a `Compute` auth client.  This came up in the context of a missing tutorial.  