### PR TITLE
fix: drop support for node.js 4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
-          filters: *release_tags
       - node6:
           filters: *release_tags
       - node8:
@@ -49,14 +47,12 @@ workflows:
           filters: *release_tags
       - lint:
           requires:
-            - node4
             - node6
             - node8
             - node10
           filters: *release_tags
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
             - node10
@@ -74,11 +70,6 @@ workflows:
     jobs: *workflow_jobs
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-        user: node
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "target": "es5"
+    "outDir": "build"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
BREAKING CHANGE: Node.js 4.x is no longer supported. 