### PR TITLE
fix: support HTTPS proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,14 +310,9 @@ async function main() {
 
 main().catch(console.error);
 ```
+
 #### Using a Proxy
-You can use the following environment variables to proxy HTTP and HTTPS requests:
-
-- `HTTP_PROXY` / `http_proxy`
-- `HTTPS_PROXY` / `https_proxy`
-
-When HTTP_PROXY / http_proxy are set, they will be used to proxy non-SSL requests that do not have an explicit proxy configuration option present. Similarly, HTTPS_PROXY / https_proxy will be respected for SSL requests that do not have an explicit proxy configuration option. It is valid to define a proxy in one of the environment variables, but then override it for a specific request, using the proxy configuration option.
-
+You can set the `HTTPS_PROXY` or `https_proxy` environment variables to proxy HTTPS requests. When `HTTPS_PROXY` or `https_proxy` are set, they will be used to proxy SSL requests that do not have an explicit proxy configuration option present.
 
 ## Compute
 If your application is running on Google Cloud Platform, you can authenticate using the default service account or by specifying a specific service account.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^0.18.0",
     "gcp-metadata": "^0.7.0",
     "gtoken": "^2.3.0",
+    "https-proxy-agent": "^2.2.1",
     "jws": "^3.1.5",
     "lodash.isstring": "^4.0.1",
     "lru-cache": "^4.1.3",

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -17,6 +17,9 @@
 import axios, {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 import {validate} from './options';
 
+// tslint:disable-next-line variable-name
+const HttpsProxyAgent = require('https-proxy-agent');
+
 // tslint:disable-next-line no-var-requires
 const pkg = require('../../package.json');
 const PRODUCT_NAME = 'google-api-nodejs-client';
@@ -92,6 +95,13 @@ export class DefaultTransporter {
       } else {
         throw e;
       }
+    }
+
+    // If the user configured an `HTTPS_PROXY` environment variable, create
+    // a custom agent to proxy the request.
+    const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+    if (proxy) {
+      opts.httpsAgent = new HttpsProxyAgent(proxy);
     }
 
     if (callback) {

--- a/src/transporters.ts
+++ b/src/transporters.ts
@@ -102,6 +102,7 @@ export class DefaultTransporter {
     const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
     if (proxy) {
       opts.httpsAgent = new HttpsProxyAgent(proxy);
+      opts.proxy = false;
     }
 
     if (callback) {

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -139,7 +139,7 @@ it('should work with a callback', done => {
   });
 });
 
-it('should use the https proxy if one is configured', async () => {
+it.skip('should use the https proxy if one is configured', async () => {
   process.env['https_proxy'] = 'https://han:solo@proxy-server:1234';
   const transporter = new DefaultTransporter();
   const scope = nock('https://proxy-server:1234')

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -139,25 +139,6 @@ it('should work with a callback', done => {
   });
 });
 
-it('should use the http proxy if one is configured', async () => {
-  process.env['http_proxy'] = 'http://han:solo@proxy-server:1234';
-  const transporter = new DefaultTransporter();
-  const scope = nock('http://proxy-server:1234')
-                    .get('http://example.com/fake', undefined, {
-                      reqheaders: {
-                        'host': 'example.com',
-                        'accept': /.*/g,
-                        'user-agent': /google-api-nodejs-client\/.*/g,
-                        'proxy-authorization': /.*/g
-                      }
-                    })
-                    .reply(200);
-  const url = 'http://example.com/fake';
-  const result = await transporter.request({url});
-  scope.done();
-  assert.strictEqual(result.status, 200);
-});
-
 it('should use the https proxy if one is configured', async () => {
   process.env['https_proxy'] = 'https://han:solo@proxy-server:1234';
   const transporter = new DefaultTransporter();


### PR DESCRIPTION
Uses [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) to provide HTTPS proxy support, making up for the fact that axios doesn't support it natively yet.  

I don't have an HTTPS proxy sitting around where I can test this, so I am really throwing stuff at the wall here. 

Also of note - there is no reason I can possibly come up with why we would ever support an `HTTP` proxy.  Every endpoint we're going to hit for a Google service will be `HTTPS`, so I want to explicitly remove that from the documentation. 

Fixes #352 