### PR TITLE
feat: simplify return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ function getAuthenticatedClient() {
         server.close();
 
         // Now that we have the code, use that to acquire tokens.
-        const r = await oAuth2Client.getToken(qs.code)
+        const tokens = await oAuth2Client.getToken(qs.code)
         // Make sure to set the credentials on the OAuth2 client.
-        oAuth2Client.setCredentials(r.tokens);
+        oAuth2Client.setCredentials(tokens);
         console.info('Tokens acquired.');
         resolve(oAuth2Client);
       }
@@ -280,7 +280,6 @@ async function main() {
     keys.private_key,
     ['https://www.googleapis.com/auth/cloud-platform'],
   );
-  await client.authorize();
   const url = `https://www.googleapis.com/dns/v1/projects/${keys.project_id}`;
   const res = await client.request({url});
   console.log(res.data);

--- a/examples/fromJSON.js
+++ b/examples/fromJSON.js
@@ -49,7 +49,6 @@ const keys = JSON.parse(keysEnvVar);
 async function main() {
   const client = auth.fromJSON(keys);
   client.scopes = ['https://www.googleapis.com/auth/cloud-platform'];
-  await client.authorize();
   const url = `https://www.googleapis.com/dns/v1/projects/${keys.project_id}`;
   const res = await client.request({ url });
   console.log(res.data);

--- a/examples/oauth2-codeVerifier.js
+++ b/examples/oauth2-codeVerifier.js
@@ -75,13 +75,13 @@ function getAuthenticatedClient() {
 
           // Now that we have the code, use that to acquire tokens.
           // Pass along the generated code verifier that matches our code challenge.
-          const r = await oAuth2Client.getToken({
+          const tokens = await oAuth2Client.getToken({
             code: qs.code,
             codeVerifier: codes.codeVerifier
           });
 
           // Make sure to set the credentials on the OAuth2 client.
-          oAuth2Client.setCredentials(r.tokens);
+          oAuth2Client.setCredentials(tokens);
           console.info('Tokens acquired.');
           resolve(oAuth2Client);
         }

--- a/examples/oauth2.js
+++ b/examples/oauth2.js
@@ -78,9 +78,9 @@ function getAuthenticatedClient() {
           server.close();
 
           // Now that we have the code, use that to acquire tokens.
-          const r = await oAuth2Client.getToken(qs.code);
+          const tokens = await oAuth2Client.getToken(qs.code);
           // Make sure to set the credentials on the OAuth2 client.
-          oAuth2Client.setCredentials(r.tokens);
+          oAuth2Client.setCredentials(tokens);
           console.info('Tokens acquired.');
           resolve(oAuth2Client);
         }

--- a/examples/puppeteer/oauth2-test.js
+++ b/examples/puppeteer/oauth2-test.js
@@ -73,9 +73,9 @@ function getAuthenticatedClient() {
           server.close();
 
           // Now that we have the code, use that to acquire tokens.
-          const r = await oAuth2Client.getToken(qs.code);
+          const tokens = await oAuth2Client.getToken(qs.code);
           // Make sure to set the credentials on the OAuth2 client.
-          oAuth2Client.setCredentials(r.tokens);
+          oAuth2Client.setCredentials(tokens);
           console.info('Tokens acquired.');
           await browser.close();
           resolve(oAuth2Client);

--- a/examples/refreshAccessToken.js
+++ b/examples/refreshAccessToken.js
@@ -95,9 +95,9 @@ function authorizeClient(client) {
           server.close();
 
           // Now that we have the code, use that to acquire tokens.
-          const r = await client.getToken(qs.code);
+          const tokens = await client.getToken(qs.code);
           // Make sure to set the credentials on the OAuth2 client.
-          client.setCredentials(r.tokens);
+          client.setCredentials(tokens);
           console.info('Tokens acquired.');
           resolve(client);
         }

--- a/examples/verifyIdToken.js
+++ b/examples/verifyIdToken.js
@@ -83,9 +83,9 @@ function getAuthenticatedClient() {
           server.close();
 
           // Now that we have the code, use that to acquire tokens.
-          const r = await oAuth2Client.getToken(qs.code);
+          const tokens = await oAuth2Client.getToken(qs.code);
           // Make sure to set the credentials on the OAuth2 client.
-          oAuth2Client.setCredentials(r.tokens);
+          oAuth2Client.setCredentials(tokens);
           console.info('Tokens acquired.');
           resolve(oAuth2Client);
         }

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -18,7 +18,7 @@ import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios
 import * as gcpMetadata from 'gcp-metadata';
 
 import {CredentialRequest, Credentials} from './credentials';
-import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
+import {OAuth2Client, RefreshOptions} from './oauth2client';
 
 export interface ComputeOptions extends RefreshOptions {
   /**
@@ -61,8 +61,7 @@ export class Compute extends OAuth2Client {
    * Refreshes the access token.
    * @param refreshToken Unused parameter
    */
-  protected async refreshTokenNoCache(refreshToken?: string|
-                                      null): Promise<GetTokenResponse> {
+  protected async refreshTokenNoCache(refreshToken?: string|null): Promise<Credentials> {
     const tokenPath = `service-accounts/${this.serviceAccountEmail}/token`;
     let res: AxiosResponse<CredentialRequest>;
     try {
@@ -78,7 +77,7 @@ export class Compute extends OAuth2Client {
       delete (tokens as CredentialRequest).expires_in;
     }
     this.emit('tokens', tokens);
-    return {tokens, res};
+    return tokens;
   }
 
   protected requestAsync<T>(opts: AxiosRequestConfig, retry = false):

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -61,7 +61,8 @@ export class Compute extends OAuth2Client {
    * Refreshes the access token.
    * @param refreshToken Unused parameter
    */
-  protected async refreshTokenNoCache(refreshToken?: string|null): Promise<Credentials> {
+  protected async refreshTokenNoCache(refreshToken?: string|
+                                      null): Promise<Credentials> {
     const tokenPath = `service-accounts/${this.serviceAccountEmail}/token`;
     let res: AxiosResponse<CredentialRequest>;
     try {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -32,7 +32,7 @@ import {Compute} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {GCPEnv, getEnv} from './envDetect';
 import {JWT, JWTOptions} from './jwtclient';
-import {OAuth2Client, RefreshOptions} from './oauth2client';
+import {Headers, OAuth2Client, RefreshOptions} from './oauth2client';
 import {UserRefreshClient} from './refreshclient';
 
 export interface ProjectIdCallback {
@@ -701,18 +701,18 @@ export class GoogleAuth {
    * Automatically obtain application default credentials, and return
    * an access token for making requests.
    */
-  async getAccessToken() {
+  async getAccessToken(): Promise<string> {
     const client = await this.getClient();
-    return (await client.getAccessToken()).token;
+    return client.getAccessToken();
   }
 
   /**
    * Obtain the HTTP headers that will provide authorization for a given
    * request.
    */
-  async getRequestHeaders(url?: string) {
+  async getRequestHeaders(url?: string): Promise<Headers> {
     const client = await this.getClient();
-    return (await client.getRequestMetadata(url)).headers;
+    return client.getRequestMetadata(url);
   }
 
   /**
@@ -720,12 +720,12 @@ export class GoogleAuth {
    * the request options.
    * @param opts Axios or Request options on which to attach the headers
    */
-  async authorizeRequest(
-      opts: {url?: string, uri?: string, headers?: http.IncomingHttpHeaders}) {
+  async authorizeRequest(opts:
+                             {url?: string, uri?: string, headers?: Headers}) {
     opts = opts || {};
     const url = opts.url || opts.uri;
     const client = await this.getClient();
-    const {headers} = await client.getRequestMetadata(url);
+    const headers = await client.getRequestMetadata(url);
     opts.headers = Object.assign(opts.headers || {}, headers);
     return opts;
   }

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -18,15 +18,14 @@ import jws from 'jws';
 import LRU from 'lru-cache';
 import * as stream from 'stream';
 import {JWTInput} from './credentials';
-import {RequestMetadataResponse} from './oauth2client';
+import {Headers} from './oauth2client';
 
 export class JWTAccess {
   email?: string|null;
   key?: string|null;
   projectId?: string;
 
-  private cache =
-      LRU<string, RequestMetadataResponse>({max: 500, maxAge: 60 * 60 * 1000});
+  private cache = LRU<string, Headers>({max: 500, maxAge: 60 * 60 * 1000});
 
   /**
    * JWTAccess service account credentials.
@@ -62,8 +61,7 @@ export class JWTAccess {
    * @returns An object that includes the authorization header.
    */
   getRequestMetadata(
-      authURI: string,
-      additionalClaims?: {[index: string]: string}): RequestMetadataResponse {
+      authURI: string, additionalClaims?: {[index: string]: string}): Headers {
     const cachedToken = this.cache.get(authURI);
     if (cachedToken) {
       return cachedToken;
@@ -93,7 +91,7 @@ export class JWTAccess {
     // Sign the jwt and add it to the cache
     const signedJWT =
         jws.sign({header: {alg: 'RS256'}, payload, secret: this.key});
-    const res = {headers: {Authorization: `Bearer ${signedJWT}`}};
+    const res = {Authorization: `Bearer ${signedJWT}`};
     this.cache.set(authURI, res);
     return res;
   }

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -15,8 +15,9 @@
  */
 
 import * as stream from 'stream';
-import {JWTInput} from './credentials';
-import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
+
+import {Credentials, JWTInput} from './credentials';
+import {OAuth2Client, RefreshOptions} from './oauth2client';
 
 export interface UserRefreshClientOptions extends RefreshOptions {
   clientId?: string;
@@ -66,7 +67,7 @@ export class UserRefreshClient extends OAuth2Client {
    * @param callback Optional callback.
    */
   protected async refreshTokenNoCache(refreshToken?: string|
-                                      null): Promise<GetTokenResponse> {
+                                      null): Promise<Credentials> {
     return super.refreshTokenNoCache(this._refreshToken);
   }
 

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -215,12 +215,9 @@ it('should accept additionalClaims', async () => {
   jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
   const testUri = 'http:/example.com/my_test_service';
-  const {headers} = await jwt.getRequestMetadata(testUri);
-  const got = headers as {
-    Authorization: string;
-  };
-  assert.notStrictEqual(null, got, 'the creds should be present');
-  const decoded = jws.decode(got.Authorization.replace('Bearer ', ''));
+  const headers = await jwt.getRequestMetadata(testUri);
+  assert.notStrictEqual(null, headers, 'the creds should be present');
+  const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
   const payload = JSON.parse(decoded.payload);
   assert.strictEqual(testUri, payload.aud);
   assert.strictEqual(someClaim, payload.someClaim);
@@ -240,13 +237,10 @@ it('should accept additionalClaims that include a target_audience',
 
      const testUri = 'http:/example.com/my_test_service';
      const scope = createGTokenMock({id_token: 'abc123'});
-     const {headers} = await jwt.getRequestMetadata(testUri);
+     const headers = await jwt.getRequestMetadata(testUri);
      scope.done();
-     const got = headers as {
-       Authorization: string;
-     };
-     assert.notStrictEqual(null, got, 'the creds should be present');
-     const decoded = got.Authorization.replace('Bearer ', '');
+     assert.notStrictEqual(null, headers, 'the creds should be present');
+     const decoded = headers.Authorization.replace('Bearer ', '');
      assert.strictEqual(decoded, 'abc123');
    });
 

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -42,11 +42,9 @@ beforeEach(() => {
 it('getRequestMetadata should create a signed JWT token as the access token',
    () => {
      const client = new JWTAccess(email, keys.private);
-     const res = client.getRequestMetadata(testUri);
-     assert.notStrictEqual(
-         null, res.headers, 'an creds object should be present');
-     const decoded = jws.decode(
-         (res.headers!.Authorization as string).replace('Bearer ', ''));
+     const headers = client.getRequestMetadata(testUri);
+     assert.notStrictEqual(null, headers, 'an creds object should be present');
+     const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
      const payload = JSON.parse(decoded.payload);
      assert.strictEqual(email, payload.iss);
      assert.strictEqual(email, payload.sub);


### PR DESCRIPTION
BREAKING CHANGE: The return types and callbacks for multiple methods have changed.  Multiple methods on the `OAuth2` class previously returned a promise that resolved with an object, which contained both the relevant return data and the response object returned from the HTTP request.  The data from the HTTP request is not necessary, so the method calls were simplified to only return the relevant data. Affected methods include:

- `OAuth2.getToken()`
- `OAuth2.refreshAccessToken()`
- `OAuth2.getAccessToken()`
- `OAuth2.getRequestMetadata()`
- `OAuth2.getFederatedSignonCerts()`
- `JWTAccess.getRequestMetadata()`

For example:

### Old code
```js
const response = await oAuth2Client.getToken(qs.code);
const tokens = response.tokens;
console.log(tokens);
```

### New code
```js
const tokens = await oAuth2Client.getToken(qs.code);
console.log(tokens);
```

---------------

A note for the readers: it's possible this is a bad idea.  I am trying to do a couple of things here:
- Reduce the number of Axios specific interfaces we export as part of the public facing API.  It's unclear what our HTTP request client of choice will be, so I want to slowly quarantine any `axios` or `request` specific behaviors. 
- Simplify the API surface.   Simply put... there's just no reason to return these response objects along with the API.  They were like this when we started, so I just never changed them.  

I am a little concerned because these changes change the return type with practically no warning, even though this is semver major.  An alternative approach could be:

- `OAuth2.getToken()` - Introduce a new `OAuth2.getTokens()` method with the new return type, and update the docs and samples.  Deprecate the `getToken` method, and delete it in 3.0.  The name `getToken` is funny, since we return multiple tokens in many cases. 
- `OAuth2.refreshAccessToken` - Deprecate it, and delete it in 3.0.  This method is already marked as `deprecated` in the jsdocs.
- `OAuth2.getAccessToken` - I got nothin.  The object return type as it is today is just weird and unexpected, but I don't know how to nuance a fix. 
- `OAuth2.getRequestMetadata()` - Introduce a `getAuthorizationHeader` method that returns a string with the Authorization header.  Deprecate this method, decom in 3.0.  I always thought this method was weird, since all it does is return a map with a single header value set.  This forces users to `Object.assign` against other headers, instead of letting them just say `myheaders.Authorization = client.getAuthorizationHeader()`.
- `OAuth2.getFederatedSignonCerts()` - I have no idea why in the world this is a public method.  We should just deprecate, and make private in 3.0.

I honestly don't know if all the churn above is really worth it, but I want to hear other opinions here :) 
