### PR TITLE
fix: use gcp-metadata for compute credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "jws": "^3.1.5",
     "lodash.isstring": "^4.0.1",
     "lru-cache": "^4.1.3",
-    "retry-axios": "^0.3.2",
     "semver": "^5.5.0"
   },
   "devDependencies": {

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import axios, {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
+import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 import * as gcpMetadata from 'gcp-metadata';
-import * as rax from 'retry-axios';
+
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
@@ -28,12 +28,11 @@ export interface ComputeOptions extends RefreshOptions {
   serviceAccountEmail?: string;
 }
 
-// Create a scoped axios instance that will retry 3 times by default
-const ax = axios.create();
-rax.attach(ax);
-
 export class Compute extends OAuth2Client {
   private serviceAccountEmail: string;
+
+  // Google Compute Engine metadata server token endpoint.
+
 
   /**
    * Google Compute Engine service account credentials.
@@ -67,20 +66,10 @@ export class Compute extends OAuth2Client {
    */
   protected async refreshTokenNoCache(refreshToken?: string|
                                       null): Promise<GetTokenResponse> {
-    const url = this.tokenUrl ||
-        `${gcpMetadata.HOST_ADDRESS}${
-                    gcpMetadata.BASE_PATH}/instance/service-accounts/${
-                    this.serviceAccountEmail}/token`;
+    const tokenPath = `service-accounts/${this.serviceAccountEmail}/token`;
     let res: AxiosResponse<CredentialRequest>;
-    // request for new token
     try {
-      // TODO: In 2.0, we should remove the ability to configure the tokenUrl,
-      // and switch this over to use the gcp-metadata package instead.
-      res = await ax.request<CredentialRequest>({
-        url,
-        headers: {[gcpMetadata.HEADER_NAME]: 'Google'},
-        raxConfig: {noResponseRetries: 3, retry: 3, instance: ax}
-      } as rax.RaxConfig);
+      res = await gcpMetadata.instance(tokenPath);
     } catch (e) {
       e.message = 'Could not refresh access token.';
       throw e;
@@ -94,7 +83,6 @@ export class Compute extends OAuth2Client {
     this.emit('tokens', tokens);
     return {tokens, res};
   }
-
 
   protected requestAsync<T>(opts: AxiosRequestConfig, retry = false):
       AxiosPromise<T> {

--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -31,9 +31,6 @@ export interface ComputeOptions extends RefreshOptions {
 export class Compute extends OAuth2Client {
   private serviceAccountEmail: string;
 
-  // Google Compute Engine metadata server token endpoint.
-
-
   /**
    * Google Compute Engine service account credentials.
    *

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -1065,21 +1065,6 @@ it('should return expiry_date', done => {
   });
 });
 
-it('should accept custom authBaseUrl and tokenUrl', async () => {
-  const authBaseUrl = 'http://authBaseUrl.com';
-  const tokenUrl = 'http://tokenUrl.com';
-  const client = new OAuth2Client(
-      CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, {authBaseUrl, tokenUrl});
-  const authUrl = client.generateAuthUrl();
-  const authUrlParts = url.parse(authUrl);
-  assert.equal(
-      authBaseUrl.toLowerCase(),
-      authUrlParts.protocol + '//' + authUrlParts.hostname);
-  const scope = nock(tokenUrl).post('/').reply(200, {});
-  const result = await client.getToken('12345');
-  scope.done();
-});
-
 it('should obtain token info', async () => {
   const accessToken = 'abc';
   const tokenInfo = {


### PR DESCRIPTION
**BREAKING CHANGE**:  The `OAuth2Client`, `JWT`, and `Compute` classes no longer accept parameters to override the authBaseUrl and tokenUrl.  These properties were largely available for testing, but there are better ways to test.  

#### Old code

```js
client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, {authBaseUrl, tokenUrl});	
```

#### New code

```js
client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);	
```