### PR TITLE
fix: deprecate the `createScopedRequired` methods

### DIFF
--- a/src/auth/computeclient.ts
+++ b/src/auth/computeclient.ts
@@ -16,7 +16,7 @@
 
 import {AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 import * as gcpMetadata from 'gcp-metadata';
-
+import * as messages from '../messages';
 import {CredentialRequest, Credentials} from './credentials';
 import {GetTokenResponse, OAuth2Client, RefreshOptions} from './oauth2client';
 
@@ -48,12 +48,14 @@ export class Compute extends OAuth2Client {
   /**
    * Indicates whether the credential requires scopes to be created by calling
    * createdScoped before use.
+   * @deprecated
    * @return Boolean indicating if scope is required.
    */
   createScopedRequired() {
     // On compute engine, scopes are specified at the compute instance's
     // creation time, and cannot be changed. For this reason, always return
     // false.
+    messages.warn(messages.COMPUTE_CREATE_SCOPED_DEPRECATED);
     return false;
   }
 

--- a/src/auth/iam.ts
+++ b/src/auth/iam.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as messages from '../messages';
+
 export interface RequestMetadata {
   'x-goog-iam-authority-selector': string;
   'x-goog-iam-authorization-token': string;
@@ -40,6 +42,7 @@ export class IAMAuth {
    */
   createScopedRequired() {
     // IAM authorization does not use scopes.
+    messages.warn(messages.IAM_CREATE_SCOPED_DEPRECATED);
     return false;
   }
 

--- a/src/auth/iam.ts
+++ b/src/auth/iam.ts
@@ -37,7 +37,7 @@ export class IAMAuth {
   /**
    * Indicates whether the credential requires scopes to be created by calling
    * createdScoped before use.
-   *
+   * @deprecated
    * @return always false
    */
   createScopedRequired() {

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -17,6 +17,9 @@
 import jws from 'jws';
 import LRU from 'lru-cache';
 import * as stream from 'stream';
+
+import * as messages from '../messages';
+
 import {JWTInput} from './credentials';
 import {RequestMetadataResponse} from './oauth2client';
 
@@ -45,11 +48,12 @@ export class JWTAccess {
   /**
    * Indicates whether the credential requires scopes to be created by calling
    * createdScoped before use.
-   *
+   * @deprecated
    * @return always false
    */
   createScopedRequired(): boolean {
     // JWT Header authentication does not use scopes.
+    messages.warn(messages.JWT_ACCESS_CREATE_SCOPED_DEPRECATED);
     return false;
   }
 

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -16,6 +16,9 @@
 
 import {GoogleToken} from 'gtoken';
 import * as stream from 'stream';
+
+import * as messages from '../messages';
+
 import {CredentialBody, Credentials, JWTInput} from './credentials';
 import {JWTAccess} from './jwtaccess';
 import {GetTokenResponse, OAuth2Client, RefreshOptions, RequestMetadataResponse} from './oauth2client';
@@ -97,7 +100,7 @@ export class JWT extends OAuth2Client {
    */
   protected async getRequestMetadataAsync(url?: string|null):
       Promise<RequestMetadataResponse> {
-    if (!this.apiKey && this.createScopedRequired() && url) {
+    if (!this.apiKey && !this.hasScopes() && url) {
       if (this.additionalClaims && (this.additionalClaims as {
                                      target_audience: string
                                    }).target_audience) {
@@ -119,19 +122,27 @@ export class JWT extends OAuth2Client {
   /**
    * Indicates whether the credential requires scopes to be created by calling
    * createScoped before use.
+   * @deprecated
    * @return false if createScoped does not need to be called.
    */
   createScopedRequired() {
-    // If scopes is null, always return true.
-    if (this.scopes) {
-      // For arrays, check the array length.
-      if (this.scopes instanceof Array) {
-        return this.scopes.length === 0;
-      }
-      // For others, convert to a string and check the length.
-      return String(this.scopes).length === 0;
+    messages.warn(messages.JWT_CREATE_SCOPED_DEPRECATED);
+    return !this.hasScopes();
+  }
+
+  /**
+   * Determine if there are currently scopes available.
+   */
+  protected hasScopes() {
+    if (!this.scopes) {
+      return false;
     }
-    return true;
+    // For arrays, check the array length.
+    if (this.scopes instanceof Array) {
+      return this.scopes.length > 0;
+    }
+    // For others, convert to a string and check the length.
+    return String(this.scopes).length > 0;
   }
 
   /**

--- a/src/auth/jwtclient.ts
+++ b/src/auth/jwtclient.ts
@@ -133,7 +133,7 @@ export class JWT extends OAuth2Client {
   /**
    * Determine if there are currently scopes available.
    */
-  protected hasScopes() {
+  private hasScopes() {
     if (!this.scopes) {
       return false;
     }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -69,3 +69,39 @@ export const DEFAULT_PROJECT_ID_DEPRECATED = {
     'method instead.'
   ].join(' ')
 };
+
+export const COMPUTE_CREATE_SCOPED_DEPRECATED = {
+  code: 'google-auth-library:DEP003',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `createScopedRequired` method on the `Compute` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library.'
+  ].join(' ')
+};
+
+export const JWT_CREATE_SCOPED_DEPRECATED = {
+  code: 'google-auth-library:DEP004',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `createScopedRequired` method on the `JWT` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library.'
+  ].join(' ')
+};
+
+export const IAM_CREATE_SCOPED_DEPRECATED = {
+  code: 'google-auth-library:DEP005',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `createScopedRequired` method on the `IAM` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library.'
+  ].join(' ')
+};
+
+export const JWT_ACCESS_CREATE_SCOPED_DEPRECATED = {
+  code: 'google-auth-library:DEP006',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `createScopedRequired` method on the `JWTAccess` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library.'
+  ].join(' ')
+};

--- a/test/test.compute.ts
+++ b/test/test.compute.ts
@@ -18,7 +18,7 @@ import assert from 'assert';
 import {AxiosError} from 'axios';
 import {BASE_PATH, HEADERS, HOST_ADDRESS} from 'gcp-metadata';
 import nock from 'nock';
-
+import sinon, {SinonSandbox} from 'sinon';
 import {Compute} from '../src';
 
 nock.disableNetConnect();
@@ -37,13 +37,16 @@ function mockExample() {
 }
 
 // set up compute client.
+let sandbox: SinonSandbox;
 let compute: Compute;
 beforeEach(() => {
   compute = new Compute();
+  sandbox = sinon.createSandbox();
 });
 
 afterEach(() => {
   nock.cleanAll();
+  sandbox.restore();
 });
 
 it('should create a dummy refresh token string', () => {
@@ -111,6 +114,13 @@ it('should not refresh if access token has not expired', async () => {
   await compute.request({url});
   assert.equal(compute.credentials.access_token, 'initial-access-token');
   scope.done();
+});
+
+it('should emit warning for createScopedRequired', () => {
+  let called = false;
+  sandbox.stub(process, 'emitWarning').callsFake(() => called = true);
+  compute.createScopedRequired();
+  assert.equal(called, true);
 });
 
 it('should return false for createScopedRequired', () => {

--- a/test/test.iam.ts
+++ b/test/test.iam.ts
@@ -15,12 +15,24 @@
  */
 
 import assert from 'assert';
+import sinon, {SinonSandbox} from 'sinon';
+
 import {IAMAuth} from '../src/index';
 
+const testSelector = 'a-test-selector';
+const testToken = 'a-test-token';
+
+let client: IAMAuth;
+let sandbox: SinonSandbox;
+beforeEach(() => {
+  sandbox = sinon.createSandbox();
+  client = new IAMAuth(testSelector, testToken);
+});
+afterEach(() => {
+  sandbox.restore();
+});
+
 it('passes the token and selector to the callback ', done => {
-  const testSelector = 'a-test-selector';
-  const testToken = 'a-test-token';
-  const client = new IAMAuth(testSelector, testToken);
   client.getRequestMetadata(null, (err, creds) => {
     assert.strictEqual(err, null, 'no error was expected: got\n' + err);
     assert.notStrictEqual(creds, null, 'metadata should be present');
@@ -28,4 +40,11 @@ it('passes the token and selector to the callback ', done => {
     assert.strictEqual(creds!['x-goog-iam-authorization-token'], testToken);
     done();
   });
+});
+
+it('should emit warning for createScopedRequired', () => {
+  let called = false;
+  sandbox.stub(process, 'emitWarning').callsFake(() => called = true);
+  client.createScopedRequired();
+  assert.equal(called, true);
 });

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -18,6 +18,7 @@ import assert from 'assert';
 import * as fs from 'fs';
 import jws from 'jws';
 import nock from 'nock';
+import sinon, {SinonSandbox} from 'sinon';
 
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 import {GoogleAuth, JWT} from '../src/index';
@@ -58,13 +59,23 @@ function createGTokenMock(body: CredentialRequest) {
 // set up the test json and the jwt instance being tested.
 let jwt: JWT;
 let json: JWTInput;
+let sandbox: SinonSandbox;
 beforeEach(() => {
   json = createJSON();
   jwt = new JWT();
+  sandbox = sinon.createSandbox();
 });
 
 afterEach(() => {
   nock.cleanAll();
+  sandbox.restore();
+});
+
+it('should emit warning for createScopedRequired', () => {
+  let called = false;
+  sandbox.stub(process, 'emitWarning').callsFake(() => called = true);
+  jwt.createScopedRequired();
+  assert.equal(called, true);
 });
 
 it('should create a dummy refresh token string', () => {

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -17,6 +17,8 @@
 import assert from 'assert';
 import * as fs from 'fs';
 import jws from 'jws';
+import sinon, {SinonSandbox} from 'sinon';
+
 import {JWTAccess} from '../src';
 
 const keypair = require('keypair');
@@ -33,10 +35,22 @@ const json = {
 const keys = keypair(1024 /* bitsize of private key */);
 const testUri = 'http:/example.com/my_test_service';
 const email = 'foo@serviceaccount.com';
-let client: JWTAccess;
 
+let client: JWTAccess;
+let sandbox: SinonSandbox;
 beforeEach(() => {
   client = new JWTAccess();
+  sandbox = sinon.createSandbox();
+});
+afterEach(() => {
+  sandbox.restore();
+});
+
+it('should emit warning for createScopedRequired', () => {
+  let called = false;
+  sandbox.stub(process, 'emitWarning').callsFake(() => called = true);
+  client.createScopedRequired();
+  assert.equal(called, true);
 });
 
 it('getRequestMetadata should create a signed JWT token as the access token',


### PR DESCRIPTION
BREAKING CHANGE:  The `createScopedRequired` method has been deprecated on multiple classes.  The `createScopedRequired` and `createScoped` methods on the `JWT` class were largely in place to help inform clients when scopes were required in an application default credential scenario.  Instead of checking if scopes are required after creating the client, instead scopes should just be passed either into the `GoogleAuth.getClient` method, or directly into the `JWT` constructor.  

### Old code
```js
auth.getApplicationDefault(function(err, authClient) {
   if (err) {
     return callback(err);
   }
  if (authClient.createScopedRequired && authClient.createScopedRequired()) {
    authClient = authClient.createScoped([
      'https://www.googleapis.com/auth/cloud-platform'
    ]);
  }
  callback(null, authClient);
});
```

### New code
```js
const client = await auth.getClient({
  scopes: ['https://www.googleapis.com/auth/cloud-platform']
});
```

