### PR TITLE
chore: deprecate getRequestMetadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -32,7 +32,7 @@ import {Compute} from './computeclient';
 import {CredentialBody, JWTInput} from './credentials';
 import {GCPEnv, getEnv} from './envDetect';
 import {JWT, JWTOptions} from './jwtclient';
-import {OAuth2Client, RefreshOptions} from './oauth2client';
+import {Headers, OAuth2Client, RefreshOptions} from './oauth2client';
 import {UserRefreshClient} from './refreshclient';
 
 export interface ProjectIdCallback {
@@ -717,8 +717,8 @@ export class GoogleAuth {
    * the request options.
    * @param opts Axios or Request options on which to attach the headers
    */
-  async authorizeRequest(
-      opts: {url?: string, uri?: string, headers?: http.IncomingHttpHeaders}) {
+  async authorizeRequest(opts:
+                             {url?: string, uri?: string, headers?: Headers}) {
     opts = opts || {};
     const url = opts.url || opts.uri;
     const client = await this.getClient();

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -709,7 +709,7 @@ export class GoogleAuth {
    */
   async getRequestHeaders(url?: string) {
     const client = await this.getClient();
-    return (await client.getRequestMetadata(url)).headers;
+    return client.getRequestHeaders(url);
   }
 
   /**
@@ -722,7 +722,7 @@ export class GoogleAuth {
     opts = opts || {};
     const url = opts.url || opts.uri;
     const client = await this.getClient();
-    const {headers} = await client.getRequestMetadata(url);
+    const headers = await client.getRequestHeaders(url);
     opts.headers = Object.assign(opts.headers || {}, headers);
     return opts;
   }

--- a/src/auth/iam.ts
+++ b/src/auth/iam.ts
@@ -48,17 +48,25 @@ export class IAMAuth {
 
   /**
    * Pass the selector and token to the metadataFn callback.
-   *
+   * @deprecated
    * @param unused_uri is required of the credentials interface
-   * @param metadataFn a callback invoked with object
-   *                   containing request metadata.
+   * @param metadataFn a callback invoked with object containing request
+   * metadata.
    */
   getRequestMetadata(
       unusedUri: string|null,
       metadataFn: (err: Error|null, metadata?: RequestMetadata) => void) {
-    metadataFn(null, {
+    messages.warn(messages.IAM_GET_REQUEST_METADATA_DEPRECATED);
+    metadataFn(null, this.getRequestHeaders());
+  }
+
+  /**
+   * Acquire the HTTP headers required to make an authenticated request.
+   */
+  getRequestHeaders() {
+    return {
       'x-goog-iam-authority-selector': this.selector,
       'x-goog-iam-authorization-token': this.token
-    });
+    };
   }
 }

--- a/src/auth/jwtaccess.ts
+++ b/src/auth/jwtaccess.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import {IncomingHttpHeaders} from 'http';
 import jws from 'jws';
 import LRU from 'lru-cache';
 import * as stream from 'stream';
+
 import * as messages from '../messages';
+
 import {JWTInput} from './credentials';
-import {RequestMetadataResponse} from './oauth2client';
+import {Headers, RequestMetadataResponse} from './oauth2client';
 
 export type Claims = {
   [index: string]: string
@@ -31,8 +32,7 @@ export class JWTAccess {
   key?: string|null;
   projectId?: string;
 
-  private cache =
-      LRU<string, IncomingHttpHeaders>({max: 500, maxAge: 60 * 60 * 1000});
+  private cache = LRU<string, Headers>({max: 500, maxAge: 60 * 60 * 1000});
 
   /**
    * JWTAccess service account credentials.
@@ -83,8 +83,7 @@ export class JWTAccess {
    * include in the payload.
    * @returns An object that includes the authorization header.
    */
-  getRequestHeaders(url: string, additionalClaims?: Claims):
-      IncomingHttpHeaders {
+  getRequestHeaders(url: string, additionalClaims?: Claims): Headers {
     const cachedToken = this.cache.get(url);
     if (cachedToken) {
       return cachedToken;

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -556,7 +556,7 @@ export class OAuth2Client extends AuthClient {
   /**
    * Retrieves the access token using refresh token
    *
-   * @deprecated use getRequestMetadata instead.
+   * @deprecated use getRequestHeaders instead.
    * @param callback callback
    */
   refreshAccessToken(): Promise<RefreshAccessTokenResponse>;
@@ -619,17 +619,9 @@ export class OAuth2Client extends AuthClient {
   }
 
   /**
-   * getRequestMetadata obtains auth metadata to be used by requests.
+   * Obtain the set of headers required to authenticate a request.
    *
-   * getRequestMetadata is the main authentication interface.  It takes an
-   * optional uri which when present is the endpoint being accessed, and a
-   * callback func(err, metadata_obj, response) where metadata_obj contains
-   * authorization metadata fields and response is an optional response object.
-   *
-   * In OAuth2Client, metadata_obj has the form.
-   *
-   * {Authorization: 'Bearer <access_token_value>'}
-   *
+   * @deprecated Use getRequestHeaders instead.
    * @param url the Uri being authorized
    * @param callback the func described above
    */
@@ -637,12 +629,27 @@ export class OAuth2Client extends AuthClient {
   getRequestMetadata(url: string|null, callback: RequestMetadataCallback): void;
   getRequestMetadata(url: string|null, callback?: RequestMetadataCallback):
       Promise<RequestMetadataResponse>|void {
+    messages.warn(messages.OAUTH_GET_REQUEST_METADATA_DEPRECATED);
     if (callback) {
       this.getRequestMetadataAsync(url).then(
           r => callback(null, r.headers, r.res), callback);
     } else {
-      return this.getRequestMetadataAsync(url);
+      return this.getRequestMetadataAsync();
     }
+  }
+
+  /**
+   * The main authentication interface.  It takes an optional url which when
+   * present is the endpoint being accessed, and returns a Promise which
+   * resolves with authorization header fields.
+   *
+   * In OAuth2Client, the result has the form:
+   * { Authorization: 'Bearer <access_token_value>' }
+   * @param url The optional url being authorized
+   */
+  async getRequestHeaders(url?: string): Promise<http.IncomingHttpHeaders> {
+    const res = await this.getRequestMetadataAsync(url);
+    return res.headers;
   }
 
   protected async getRequestMetadataAsync(url?: string|null):

--- a/src/auth/oauth2client.ts
+++ b/src/auth/oauth2client.ts
@@ -30,6 +30,10 @@ export type Certificates = {
   [index: string]: string
 };
 
+export type Headers = {
+  [index: string]: string
+};
+
 export enum CodeChallengeMethod {
   Plain = 'plain',
   S256 = 'S256'
@@ -270,12 +274,12 @@ export interface RefreshAccessTokenResponse {
 }
 
 export interface RequestMetadataResponse {
-  headers: http.IncomingHttpHeaders;
+  headers: Headers;
   res?: AxiosResponse<void>|null;
 }
 
 export interface RequestMetadataCallback {
-  (err: AxiosError|null, headers?: http.IncomingHttpHeaders,
+  (err: AxiosError|null, headers?: Headers,
    res?: AxiosResponse<void>|null): void;
 }
 
@@ -647,7 +651,7 @@ export class OAuth2Client extends AuthClient {
    * { Authorization: 'Bearer <access_token_value>' }
    * @param url The optional url being authorized
    */
-  async getRequestHeaders(url?: string): Promise<http.IncomingHttpHeaders> {
+  async getRequestHeaders(url?: string): Promise<Headers> {
     const res = await this.getRequestMetadataAsync(url);
     return res.headers;
   }

--- a/src/auth/refreshclient.ts
+++ b/src/auth/refreshclient.ts
@@ -127,19 +127,18 @@ export class UserRefreshClient extends OAuth2Client {
             'Must pass in a stream containing the user refresh token.'));
       }
       let s = '';
-      inputStream.setEncoding('utf8');
-      inputStream.on('data', (chunk) => {
-        s += chunk;
-      });
-      inputStream.on('end', () => {
-        try {
-          const data = JSON.parse(s);
-          this.fromJSON(data);
-          return resolve();
-        } catch (err) {
-          return reject(err);
-        }
-      });
+      inputStream.setEncoding('utf8')
+          .on('error', reject)
+          .on('data', (chunk) => s += chunk)
+          .on('end', () => {
+            try {
+              const data = JSON.parse(s);
+              this.fromJSON(data);
+              return resolve();
+            } catch (err) {
+              return reject(err);
+            }
+          });
     });
   }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -111,7 +111,36 @@ export const REFRESH_ACCESS_TOKEN_DEPRECATED = {
   type: WarningTypes.DEPRECATION,
   message: [
     'The `refreshAccessToken` method has been deprecated, and will be removed',
-    'in the 3.0 release of google-auth-library. Please use the `getRequestMetadata`',
+    'in the 3.0 release of google-auth-library. Please use the `getRequestHeaders`',
     'method instead.'
+  ].join(' ')
+};
+export const OAUTH_GET_REQUEST_METADATA_DEPRECATED = {
+  code: 'google-auth-library:DEP004',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `getRequestMetadata` method on the `OAuth2` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library. Please use',
+    'the `getRequestHeaders` method instead.'
+  ].join(' ')
+};
+
+export const IAM_GET_REQUEST_METADATA_DEPRECATED = {
+  code: 'google-auth-library:DEP005',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `getRequestMetadata` method on the `IAM` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library. Please use',
+    'the `getRequestHeaders` method instead.'
+  ].join(' ')
+};
+
+export const JWT_ACCESS_GET_REQUEST_METADATA_DEPRECATED = {
+  code: 'google-auth-library:DEP006',
+  type: WarningTypes.DEPRECATION,
+  message: [
+    'The `getRequestMetadata` method on the `JWTAccess` class has been deprecated,',
+    'and will be removed in the 3.0 release of google-auth-library. Please use',
+    'the `getRequestHeaders` method instead.'
   ].join(' ')
 };

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -192,8 +192,7 @@ it('gets a jwt header access token', async () => {
   const testUri = 'http:/example.com/my_test_service';
   const got = await jwt.getRequestHeaders(testUri);
   assert.notStrictEqual(null, got, 'the creds should be present');
-  const decoded =
-      jws.decode((got.Authorization as string).replace('Bearer ', ''));
+  const decoded = jws.decode(got.Authorization.replace('Bearer ', ''));
   const payload = JSON.parse(decoded.payload);
   assert.strictEqual(email, payload.iss);
   assert.strictEqual(email, payload.sub);
@@ -214,8 +213,7 @@ it('should accept additionalClaims', async () => {
   const testUri = 'http:/example.com/my_test_service';
   const got = await jwt.getRequestHeaders(testUri);
   assert.notStrictEqual(null, got, 'the creds should be present');
-  const decoded =
-      jws.decode((got.Authorization as string).replace('Bearer ', ''));
+  const decoded = jws.decode(got.Authorization.replace('Bearer ', ''));
   const payload = JSON.parse(decoded.payload);
   assert.strictEqual(testUri, payload.aud);
   assert.strictEqual(someClaim, payload.someClaim);
@@ -237,7 +235,7 @@ it('should accept additionalClaims that include a target_audience',
      const got = await jwt.getRequestHeaders(testUri);
      scope.done();
      assert.notStrictEqual(null, got, 'the creds should be present');
-     const decoded = (got.Authorization as string).replace('Bearer ', '');
+     const decoded = got.Authorization.replace('Bearer ', '');
      assert.strictEqual(decoded, 'abc123');
    });
 

--- a/test/test.jwt.ts
+++ b/test/test.jwt.ts
@@ -20,7 +20,7 @@ import jws from 'jws';
 import nock from 'nock';
 import sinon, {SinonSandbox} from 'sinon';
 
-import {GoogleAuth, JWT} from '../src';
+import {JWT} from '../src';
 import {CredentialRequest, JWTInput} from '../src/auth/credentials';
 
 const keypair = require('keypair');
@@ -160,7 +160,7 @@ it('should emit an event for tokens', (done) => {
      }).getAccessToken();
 });
 
-it('can obtain new access token when scopes are set', (done) => {
+it('can obtain new access token when scopes are set', async () => {
   const jwt = new JWT({
     email: 'foo@serviceaccount.com',
     keyFile: PEM_PATH,
@@ -170,24 +170,16 @@ it('can obtain new access token when scopes are set', (done) => {
   jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
   const wantedToken = 'abc123';
-  const want = 'Bearer ' + wantedToken;
+  const want = `Bearer ${wantedToken}`;
   const scope = createGTokenMock({access_token: wantedToken});
-  jwt.getRequestMetadata(null, (err, result) => {
-    scope.done();
-    assert.strictEqual(null, err, 'no error was expected: got\n' + err);
-    const got = result as {
-      Authorization: string;
-    };
-    assert.strictEqual(
-        want, got.Authorization,
-        'the authorization header was wrong: ' + got.Authorization);
-    done();
-  });
+  const headers = await jwt.getRequestHeaders();
+  scope.done();
+  assert.strictEqual(
+      want, headers.Authorization,
+      `the authorization header was wrong: ${headers.Authorization}`);
 });
 
-
-
-it('gets a jwt header access token', (done) => {
+it('gets a jwt header access token', async () => {
   const keys = keypair(1024 /* bitsize of private key */);
   const email = 'foo@serviceaccount.com';
   const jwt = new JWT({
@@ -198,24 +190,18 @@ it('gets a jwt header access token', (done) => {
   jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
   const testUri = 'http:/example.com/my_test_service';
-  jwt.getRequestMetadata(testUri, (err, result) => {
-    const got = result as {
-      Authorization: string;
-    };
-    assert.strictEqual(null, err, 'no error was expected: got\n' + err);
-    assert.notStrictEqual(null, got, 'the creds should be present');
-    const decoded = jws.decode(got.Authorization.replace('Bearer ', ''));
-    const payload = JSON.parse(decoded.payload);
-    assert.strictEqual(email, payload.iss);
-    assert.strictEqual(email, payload.sub);
-    assert.strictEqual(testUri, payload.aud);
-    done();
-  });
+  const got = await jwt.getRequestHeaders(testUri);
+  assert.notStrictEqual(null, got, 'the creds should be present');
+  const decoded =
+      jws.decode((got.Authorization as string).replace('Bearer ', ''));
+  const payload = JSON.parse(decoded.payload);
+  assert.strictEqual(email, payload.iss);
+  assert.strictEqual(email, payload.sub);
+  assert.strictEqual(testUri, payload.aud);
 });
 
 it('should accept additionalClaims', async () => {
   const keys = keypair(1024 /* bitsize of private key */);
-  const email = 'foo@serviceaccount.com';
   const someClaim = 'cat-on-my-desk';
   const jwt = new JWT({
     email: 'foo@serviceaccount.com',
@@ -226,12 +212,10 @@ it('should accept additionalClaims', async () => {
   jwt.credentials = {refresh_token: 'jwt-placeholder'};
 
   const testUri = 'http:/example.com/my_test_service';
-  const {headers} = await jwt.getRequestMetadata(testUri);
-  const got = headers as {
-    Authorization: string;
-  };
+  const got = await jwt.getRequestHeaders(testUri);
   assert.notStrictEqual(null, got, 'the creds should be present');
-  const decoded = jws.decode(got.Authorization.replace('Bearer ', ''));
+  const decoded =
+      jws.decode((got.Authorization as string).replace('Bearer ', ''));
   const payload = JSON.parse(decoded.payload);
   assert.strictEqual(testUri, payload.aud);
   assert.strictEqual(someClaim, payload.someClaim);
@@ -240,7 +224,6 @@ it('should accept additionalClaims', async () => {
 it('should accept additionalClaims that include a target_audience',
    async () => {
      const keys = keypair(1024 /* bitsize of private key */);
-     const email = 'foo@serviceaccount.com';
      const jwt = new JWT({
        email: 'foo@serviceaccount.com',
        key: keys.private,
@@ -251,13 +234,10 @@ it('should accept additionalClaims that include a target_audience',
 
      const testUri = 'http:/example.com/my_test_service';
      const scope = createGTokenMock({id_token: 'abc123'});
-     const {headers} = await jwt.getRequestMetadata(testUri);
+     const got = await jwt.getRequestHeaders(testUri);
      scope.done();
-     const got = headers as {
-       Authorization: string;
-     };
      assert.notStrictEqual(null, got, 'the creds should be present');
-     const decoded = got.Authorization.replace('Bearer ', '');
+     const decoded = (got.Authorization as string).replace('Bearer ', '');
      assert.strictEqual(decoded, 'abc123');
    });
 
@@ -349,7 +329,6 @@ it('should refresh token if expired', (done) => {
 
 it('should refresh if access token will expired soon and time to refresh before expiration is set',
    (done) => {
-     const auth = new GoogleAuth();
      const jwt = new JWT({
        email: 'foo@serviceaccount.com',
        keyFile: PEM_PATH,
@@ -476,10 +455,9 @@ it('should return expiry_date in milliseconds', async () => {
 
   const scope = createGTokenMock({access_token: 'token', expires_in: 100});
   jwt.credentials.access_token = null;
-  const result = await jwt.getRequestMetadata();
+  await jwt.getRequestHeaders();
   scope.done();
   const dateInMillis = (new Date()).getTime();
-  const expiryDate = new Date(jwt.credentials.expiry_date!);
   assert.equal(
       dateInMillis.toString().length,
       jwt.credentials.expiry_date!.toString().length);
@@ -662,27 +640,27 @@ it('fromJson should error on missing private_key', () => {
 });
 
 it('fromJson should create JWT with client_email', () => {
-  const result = jwt.fromJSON(json);
+  jwt.fromJSON(json);
   assert.equal(json.client_email, jwt.email);
 });
 
 it('fromJson should create JWT with private_key', () => {
-  const result = jwt.fromJSON(json);
+  jwt.fromJSON(json);
   assert.equal(json.private_key, jwt.key);
 });
 
 it('fromJson should create JWT with null scopes', () => {
-  const result = jwt.fromJSON(json);
+  jwt.fromJSON(json);
   assert.equal(null, jwt.scopes);
 });
 
 it('fromJson should create JWT with null subject', () => {
-  const result = jwt.fromJSON(json);
+  jwt.fromJSON(json);
   assert.equal(null, jwt.subject);
 });
 
 it('fromJson should create JWT with null keyFile', () => {
-  const result = jwt.fromJSON(json);
+  jwt.fromJSON(json);
   assert.equal(null, jwt.keyFile);
 });
 
@@ -762,7 +740,7 @@ it('fromAPIKey should error with invalid api key type', () => {
 
 it('fromAPIKey should set the .apiKey property on the instance', () => {
   const KEY = 'test';
-  const result = jwt.fromAPIKey(KEY);
+  jwt.fromAPIKey(KEY);
   assert.strictEqual(jwt.apiKey, KEY);
 });
 

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -58,8 +58,7 @@ it('getRequestHeaders should create a signed JWT token as the access token',
      const client = new JWTAccess(email, keys.private);
      const headers = client.getRequestHeaders(testUri);
      assert.notStrictEqual(null, headers, 'an creds object should be present');
-     const decoded =
-         jws.decode((headers.Authorization as string).replace('Bearer ', ''));
+     const decoded = jws.decode(headers.Authorization.replace('Bearer ', ''));
      const payload = JSON.parse(decoded.payload);
      assert.strictEqual(email, payload.iss);
      assert.strictEqual(email, payload.sub);

--- a/test/test.jwtaccess.ts
+++ b/test/test.jwtaccess.ts
@@ -20,6 +20,7 @@ import jws from 'jws';
 import sinon, {SinonSandbox} from 'sinon';
 
 import {JWTAccess} from '../src';
+import * as messages from '../src/messages';
 
 const keypair = require('keypair');
 
@@ -47,51 +48,49 @@ afterEach(() => {
 });
 
 it('should emit warning for createScopedRequired', () => {
-  let called = false;
-  sandbox.stub(process, 'emitWarning').callsFake(() => called = true);
+  const stub = sandbox.stub(process, 'emitWarning');
   client.createScopedRequired();
-  assert.equal(called, true);
+  assert(stub.called);
 });
 
-it('getRequestMetadata should create a signed JWT token as the access token',
+it('getRequestHeaders should create a signed JWT token as the access token',
    () => {
      const client = new JWTAccess(email, keys.private);
-     const res = client.getRequestMetadata(testUri);
-     assert.notStrictEqual(
-         null, res.headers, 'an creds object should be present');
-     const decoded = jws.decode(
-         (res.headers!.Authorization as string).replace('Bearer ', ''));
+     const headers = client.getRequestHeaders(testUri);
+     assert.notStrictEqual(null, headers, 'an creds object should be present');
+     const decoded =
+         jws.decode((headers.Authorization as string).replace('Bearer ', ''));
      const payload = JSON.parse(decoded.payload);
      assert.strictEqual(email, payload.iss);
      assert.strictEqual(email, payload.sub);
      assert.strictEqual(testUri, payload.aud);
    });
 
-it('getRequestMetadata should not allow overriding with additionalClaims', () => {
+it('getRequestHeaders should not allow overriding with additionalClaims', () => {
   const client = new JWTAccess(email, keys.private);
   const additionalClaims = {iss: 'not-the-email'};
   assert.throws(() => {
-    client.getRequestMetadata(testUri, additionalClaims);
+    client.getRequestHeaders(testUri, additionalClaims);
   }, /^Error: The 'iss' property is not allowed when passing additionalClaims. This claim is included in the JWT by default.$/);
 });
 
-it('getRequestMetadata should return a cached token on the second request',
+it('getRequestHeaders should return a cached token on the second request',
    () => {
      const client = new JWTAccess(email, keys.private);
-     const res = client.getRequestMetadata(testUri);
-     const res2 = client.getRequestMetadata(testUri);
+     const res = client.getRequestHeaders(testUri);
+     const res2 = client.getRequestHeaders(testUri);
      assert.strictEqual(res, res2);
    });
 
-it('getRequestMetadata should not return cached tokens older than an hour',
+it('getRequestHeaders should not return cached tokens older than an hour',
    () => {
      const client = new JWTAccess(email, keys.private);
-     const res = client.getRequestMetadata(testUri);
+     const res = client.getRequestHeaders(testUri);
      const realDateNow = Date.now;
      try {
        // go forward in time one hour (plus a little)
        Date.now = () => realDateNow() + (1000 * 60 * 60) + 10;
-       const res2 = client.getRequestMetadata(testUri);
+       const res2 = client.getRequestHeaders(testUri);
        assert.notEqual(res, res2);
      } finally {
        // return date.now to it's normally scheduled programming
@@ -169,3 +168,10 @@ it('fromStream should construct a JWT Header instance from a stream',
      assert.equal(json.private_key, client.key);
      assert.equal(json.client_email, client.email);
    });
+
+it('should warn about deprecation of getRequestMetadata', () => {
+  const client = new JWTAccess(email, keys.private);
+  const stub = sandbox.stub(messages, 'warn');
+  client.getRequestMetadata(testUri);
+  assert.equal(stub.calledOnce, true);
+});

--- a/test/test.oauth2.ts
+++ b/test/test.oauth2.ts
@@ -26,6 +26,7 @@ import url from 'url';
 
 import {CodeChallengeMethod, OAuth2Client} from '../src';
 import {LoginTicket} from '../src/auth/loginticket';
+import * as messages from '../src/messages';
 assert.rejects = require('assert-rejects');
 
 nock.disableNetConnect();
@@ -1085,4 +1086,12 @@ it('should obtain token info', async () => {
   assert.equal(info.aud, tokenInfo.aud);
   assert.equal(info.user_id, tokenInfo.user_id);
   assert.deepEqual(info.scopes, tokenInfo.scope.split(' '));
+});
+
+it('should warn about deprecation of getRequestMetadata', done => {
+  const stub = sandbox.stub(messages, 'warn');
+  client.getRequestMetadata(null, () => {
+    assert.equal(stub.calledOnce, true);
+    done();
+  });
 });


### PR DESCRIPTION
BREAKING CHANGE:  The `getRequestMetadata` method has been deprecated on the `IAM`, `OAuth2`, `JWT`, and `JWTAccess` classes.  The `getRequestHeaders` method should be used instead.  The methods have a subtle difference:  the `getRequestMetadata` method returns an object with a headers property, which contains the authorization header.  The `getRequestHeaders` method simply returns the headers.  

### Old code
```js
const client = await auth.getClient();
const res = await client.getRequestMetadata();
const headers = res.headers;
```

### New code
```js
const client = await auth.getClient();
const headers = await client.getRequestHeaders();
```

