### PR TITLE
chore: update gcp-metadata for isAvailable fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,9 +1129,9 @@
       "dev": true
     },
     "gcp-metadata": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
-      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.7.0.tgz",
+      "integrity": "sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==",
       "requires": {
         "axios": "^0.18.0",
         "extend": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "axios": "^0.18.0",
-    "gcp-metadata": "^0.6.3",
+    "gcp-metadata": "^0.7.0",
     "gtoken": "^2.3.0",
     "jws": "^3.1.5",
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
The `isAvailable` function no longer swallows unexpected errors which
means that we can start reporting better errors back to users of this
library.

Previously #398.