### PR TITLE
fix: update env var for detecting gcf

### DIFF
--- a/src/auth/envDetect.ts
+++ b/src/auth/envDetect.ts
@@ -52,7 +52,8 @@ function isAppEngine() {
 }
 
 function isCloudFunction() {
-  return !!process.env.FUNCTION_NAME;
+  // X_GOOGLE_FUNCTION_NAME is a new alias for FUNCTION_NAME.
+  return !!process.env.X_GOOGLE_FUNCTION_NAME || !!process.env.FUNCTION_NAME;
 }
 
 async function isKubernetesEngine() {

--- a/test/test.googleauth.ts
+++ b/test/test.googleauth.ts
@@ -1244,8 +1244,12 @@ it('should get the current environment if GKE', async () => {
 
 it('should get the current environment if GCF', async () => {
   envDetect.clear();
+  // X_GOOGLE_FUNCTION_NAME is newer.
+  mockEnvVar('X_GOOGLE_FUNCTION_NAME', 'DOGGY');
+  let env = await auth.getEnv();
+  assert.equal(env, envDetect.GCPEnv.CLOUD_FUNCTIONS);
   mockEnvVar('FUNCTION_NAME', 'DOGGY');
-  const env = await auth.getEnv();
+  env = await auth.getEnv();
   assert.equal(env, envDetect.GCPEnv.CLOUD_FUNCTIONS);
 });
 


### PR DESCRIPTION
`X_GOOGLE_FUNCTION_NAME` was introduced sometime earlier this year. It seems to contain the same value as `FUNCTION_NAME` and probably functions as a replacement; we should check this env var as well in case `FUNCTION_NAME` eventually disappears.